### PR TITLE
fix: move ghcr from blockfrost to hyperledger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
         id: firefly-cardanoconnect-meta
         uses: docker/metadata-action@v5.6.1
         with:
-          images: ghcr.io/blockfrost/firefly-cardanoconnect
+          images: ghcr.io/hyperledger/firefly-cardanoconnect
       - name: Build and push Docker image for firefly-cardanoconnect
         id: firefly-cardanoconnect-push
         uses: docker/build-push-action@v6.10.0
@@ -71,12 +71,11 @@ jobs:
         id: firefly-cardanosigner-meta
         uses: docker/metadata-action@v5.6.1
         with:
-          images: ghcr.io/blockfrost/firefly-cardanosigner
+          images: ghcr.io/hyperledger/firefly-cardanosigner
       - name: Build and push Docker image for firefly-cardanosigner
         id: firefly-cardanosigner-push
         uses: docker/build-push-action@v6.10.0
         with:
-          registry: ghcr.io
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: .

--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
         retries: 12
 
   firefly-cardanoconnect:
-    image: ghcr.io/blockfrost/firefly-cardanoconnect:main
+    image: ghcr.io/hyperledger/firefly-cardanoconnect:main
     build:
       context: ..
       target: firefly-cardanoconnect
@@ -59,7 +59,7 @@ services:
       - ./connect.yaml:/app/config.yaml
 
   firefly-cardanosigner:
-    image: ghcr.io/blockfrost/firefly-cardanosigner:main
+    image: ghcr.io/hyperledger/firefly-cardanosigner:main
     build:
       context: ..
       target: firefly-cardanosigner


### PR DESCRIPTION
# Context

When this repo moved from blockfrost to hyperledger, it lost access to the blockfrost GHCR image repository. Switch to using one for hyperledger, so that it's allowed to publish.

# Important Changes Introduced

Uses a new GHCR repository for new releases