### PR TITLE
fix: use the correct volume for the firefly-cardanoconnect DB

### DIFF
--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
       - 5018:5018
     volumes:
       - connect-contracts:/contracts
-      - ./db:/db
+      - connect-db:/db
       - ./connect.yaml:/app/config.yaml
 
   firefly-cardanosigner:


### PR DESCRIPTION
# Context

This docker compose file creates a volume for the DB, but was saving it to disk instead.

# Important Changes Introduced

Use the DB volume for its intended purpose.