### PR TITLE
Custom events (using balius)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,6 +1128,7 @@ version = "0.1.0"
 dependencies = [
  "balius-sdk",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 [[package]]
 name = "balius-macros"
 version = "0.1.0"
-source = "git+https://github.com/txpipe/balius.git?rev=cf2791d#cf2791d63658cd062384a11d2322480ba8f82039"
+source = "git+https://github.com/txpipe/balius.git?rev=e54ec4d#e54ec4d56a52f0f8097bb253f259fae4ecb64d34"
 dependencies = [
  "quote",
  "syn",
@@ -366,7 +366,7 @@ dependencies = [
 [[package]]
 name = "balius-runtime"
 version = "0.1.0"
-source = "git+https://github.com/txpipe/balius.git?rev=cf2791d#cf2791d63658cd062384a11d2322480ba8f82039"
+source = "git+https://github.com/txpipe/balius.git?rev=e54ec4d#e54ec4d56a52f0f8097bb253f259fae4ecb64d34"
 dependencies = [
  "async-trait",
  "flate2",
@@ -390,7 +390,7 @@ dependencies = [
 [[package]]
 name = "balius-sdk"
 version = "0.1.0"
-source = "git+https://github.com/txpipe/balius.git?rev=cf2791d#cf2791d63658cd062384a11d2322480ba8f82039"
+source = "git+https://github.com/txpipe/balius.git?rev=e54ec4d#e54ec4d56a52f0f8097bb253f259fae4ecb64d34"
 dependencies = [
  "balius-macros",
  "hex",
@@ -1127,6 +1127,7 @@ name = "firefly-balius"
 version = "0.1.0"
 dependencies = [
  "balius-sdk",
+ "hex",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,6 +1148,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "firefly-cardano-deploy"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+ "wat",
+ "wit-component 0.223.0",
+]
+
+[[package]]
 name = "firefly-cardano-deploy-contract"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 [[package]]
 name = "balius-macros"
 version = "0.1.0"
-source = "git+https://github.com/txpipe/balius.git?rev=e54ec4d#e54ec4d56a52f0f8097bb253f259fae4ecb64d34"
+source = "git+https://github.com/txpipe/balius.git?rev=dd56cd0#dd56cd03ee7912762e03d83dda33f8ae93f05033"
 dependencies = [
  "quote",
  "syn",
@@ -366,7 +366,7 @@ dependencies = [
 [[package]]
 name = "balius-runtime"
 version = "0.1.0"
-source = "git+https://github.com/txpipe/balius.git?rev=e54ec4d#e54ec4d56a52f0f8097bb253f259fae4ecb64d34"
+source = "git+https://github.com/txpipe/balius.git?rev=dd56cd0#dd56cd03ee7912762e03d83dda33f8ae93f05033"
 dependencies = [
  "async-trait",
  "flate2",
@@ -390,7 +390,7 @@ dependencies = [
 [[package]]
 name = "balius-sdk"
 version = "0.1.0"
-source = "git+https://github.com/txpipe/balius.git?rev=e54ec4d#e54ec4d56a52f0f8097bb253f259fae4ecb64d34"
+source = "git+https://github.com/txpipe/balius.git?rev=dd56cd0#dd56cd03ee7912762e03d83dda33f8ae93f05033"
 dependencies = [
  "balius-macros",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,7 @@ name = "firefly-balius"
 version = "0.1.0"
 dependencies = [
  "balius-sdk",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "firefly-cardanosigner",
     "firefly-server",
     "scripts/demo",
+    "scripts/deploy",
     "scripts/deploy-contract",
 ]
 

--- a/firefly-balius/Cargo.toml
+++ b/firefly-balius/Cargo.toml
@@ -6,3 +6,4 @@ repository = "https://github.com/blockfrost/firefly-cardano"
 
 [dependencies]
 balius-sdk = { git = "https://github.com/txpipe/balius.git", rev = "cf2791d" }
+serde = { version = "1", features = ["derive"] }

--- a/firefly-balius/Cargo.toml
+++ b/firefly-balius/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 repository = "https://github.com/blockfrost/firefly-cardano"
 
 [dependencies]
-balius-sdk = { git = "https://github.com/txpipe/balius.git", rev = "e54ec4d" }
+balius-sdk = { git = "https://github.com/txpipe/balius.git", rev = "dd56cd0" }
 hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/firefly-balius/Cargo.toml
+++ b/firefly-balius/Cargo.toml
@@ -7,3 +7,4 @@ repository = "https://github.com/blockfrost/firefly-cardano"
 [dependencies]
 balius-sdk = { git = "https://github.com/txpipe/balius.git", rev = "cf2791d" }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/firefly-balius/Cargo.toml
+++ b/firefly-balius/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 repository = "https://github.com/blockfrost/firefly-cardano"
 
 [dependencies]
-balius-sdk = { git = "https://github.com/txpipe/balius.git", rev = "cf2791d" }
+balius-sdk = { git = "https://github.com/txpipe/balius.git", rev = "e54ec4d" }
+hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/firefly-balius/src/lib.rs
+++ b/firefly-balius/src/lib.rs
@@ -1,6 +1,11 @@
-use balius_sdk::txbuilder::{
-    primitives::TransactionInput, BuildContext, BuildError, InputExpr, UtxoSource,
+use std::marker::PhantomData;
+
+use balius_sdk::{
+    txbuilder::{primitives::TransactionInput, BuildContext, BuildError, InputExpr, UtxoSource},
+    wit, Ack, Params, Worker, WorkerResult,
+    _internal::Handler,
 };
+use serde::Deserialize;
 
 pub struct CoinSelectionInput(pub UtxoSource, pub u64);
 
@@ -41,5 +46,67 @@ impl InputExpr for CoinSelectionInput {
         } else {
             Err(BuildError::OutputsTooHigh)
         }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct SubmittedTx {
+    pub method: String,
+    pub hash: String,
+}
+
+pub struct SubmittedTxHandler<F, C>
+where
+    F: Fn(C, SubmittedTx) -> WorkerResult<Ack> + 'static,
+    C: TryFrom<wit::Config>,
+{
+    func: F,
+    phantom: PhantomData<C>,
+}
+
+impl<F, C> From<F> for SubmittedTxHandler<F, C>
+where
+    F: Fn(C, SubmittedTx) -> WorkerResult<Ack> + 'static,
+    C: TryFrom<wit::Config>,
+{
+    fn from(func: F) -> Self {
+        Self {
+            func,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<F, C> Handler for SubmittedTxHandler<F, C>
+where
+    F: Fn(C, SubmittedTx) -> WorkerResult<Ack> + Send + Sync + 'static,
+    C: TryFrom<wit::Config, Error = balius_sdk::Error> + Send + Sync + 'static,
+{
+    fn handle(
+        &self,
+        config: wit::Config,
+        event: wit::Event,
+    ) -> Result<wit::Response, wit::HandleError> {
+        let config: C = config.try_into()?;
+        let event: Params<SubmittedTx> = event.try_into()?;
+        let response = (self.func)(config, event.0)?;
+        Ok(response.try_into()?)
+    }
+}
+
+pub trait WorkerExt {
+    fn with_tx_submitted_handler<C, F>(self, func: F) -> Self
+    where
+        C: TryFrom<wit::Config, Error = balius_sdk::Error> + Send + Sync + 'static,
+        F: Fn(C, SubmittedTx) -> WorkerResult<Ack> + Send + Sync + 'static;
+}
+
+impl WorkerExt for Worker {
+    fn with_tx_submitted_handler<C, F>(self, func: F) -> Self
+    where
+        C: TryFrom<wit::Config, Error = balius_sdk::Error> + Send + Sync + 'static,
+        F: Fn(C, SubmittedTx) -> WorkerResult<Ack> + Send + Sync + 'static,
+    {
+        self.with_request_handler("__tx_submitted", SubmittedTxHandler::from(func))
     }
 }

--- a/firefly-balius/src/lib.rs
+++ b/firefly-balius/src/lib.rs
@@ -110,3 +110,21 @@ impl WorkerExt for Worker {
         self.with_request_handler("__tx_submitted", SubmittedTxHandler::from(func))
     }
 }
+
+pub mod kv {
+    use balius_sdk::{wit::balius::app::kv, WorkerResult};
+    use serde::{Deserialize, Serialize};
+
+    pub fn get<D: for<'a> Deserialize<'a>>(key: &str) -> WorkerResult<Option<D>> {
+        match kv::get_value(key) {
+            Ok(bytes) => Ok(Some(serde_json::from_slice(&bytes)?)),
+            Err(kv::KvError::NotFound(_)) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    pub fn set<S: Serialize>(key: &str, value: &S) -> WorkerResult<()> {
+        kv::set_value(key, &serde_json::to_vec(value)?)?;
+        Ok(())
+    }
+}

--- a/firefly-balius/src/lib.rs
+++ b/firefly-balius/src/lib.rs
@@ -1,11 +1,11 @@
-use std::marker::PhantomData;
+use std::{collections::HashMap, marker::PhantomData};
 
 use balius_sdk::{
     txbuilder::{primitives::TransactionInput, BuildContext, BuildError, InputExpr, UtxoSource},
-    wit, Ack, Params, Worker, WorkerResult,
+    wit, Ack, Params, Utxo, Worker, WorkerResult,
     _internal::Handler,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 pub struct CoinSelectionInput(pub UtxoSource, pub u64);
 
@@ -127,4 +127,48 @@ pub mod kv {
         kv::set_value(key, &serde_json::to_vec(value)?)?;
         Ok(())
     }
+}
+
+pub trait EventData: Serialize {
+    fn signature(&self) -> String;
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Event {
+    pub block_hash: Vec<u8>,
+    pub tx_hash: Vec<u8>,
+    pub signature: String,
+    pub data: serde_json::Value,
+}
+
+impl Event {
+    pub fn new<D, E: EventData>(utxo: &Utxo<D>, data: &E) -> WorkerResult<Self> {
+        Ok(Self {
+            block_hash: utxo.block_hash.clone(),
+            tx_hash: utxo.tx_hash.clone(),
+            signature: data.signature(),
+            data: serde_json::to_value(data)?,
+        })
+    }
+}
+
+pub fn emit_events(events: Vec<Event>) -> WorkerResult<()> {
+    if events.is_empty() {
+        return Ok(());
+    }
+
+    let mut block_events: HashMap<String, Vec<Event>> = HashMap::new();
+    for event in events {
+        let block_hash = hex::encode(&event.block_hash);
+        block_events.entry(block_hash).or_default().push(event);
+    }
+
+    for (block, mut events) in block_events {
+        let events_key = format!("__events_{block}");
+        let mut all_events: Vec<Event> = kv::get(&events_key)?.unwrap_or_default();
+        all_events.append(&mut events);
+        kv::set(&events_key, &all_events)?;
+    }
+
+    Ok(())
 }

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -9,7 +9,7 @@ aide = { version = "0.14", features = ["axum", "axum-json", "axum-query"] }
 anyhow = "1"
 async-trait = "0.1"
 axum = { version = "0.8", features = ["macros", "ws"] }
-balius-runtime = { git = "https://github.com/txpipe/balius.git", rev = "e54ec4d" }
+balius-runtime = { git = "https://github.com/txpipe/balius.git", rev = "dd56cd0" }
 blockfrost = { git = "https://github.com/SupernaviX/blockfrost-rust.git", rev = "cfa7a5e", default-features = false, features = ["rustls-tls"] }
 blockfrost-openapi = "0.1.69"
 clap = { version = "4", features = ["derive"] }

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -9,7 +9,7 @@ aide = { version = "0.14", features = ["axum", "axum-json", "axum-query"] }
 anyhow = "1"
 async-trait = "0.1"
 axum = { version = "0.8", features = ["macros", "ws"] }
-balius-runtime = { git = "https://github.com/txpipe/balius.git", rev = "cf2791d" }
+balius-runtime = { git = "https://github.com/txpipe/balius.git", rev = "e54ec4d" }
 blockfrost = { git = "https://github.com/SupernaviX/blockfrost-rust.git", rev = "cfa7a5e", default-features = false, features = ["rustls-tls"] }
 blockfrost-openapi = "0.1.69"
 clap = { version = "4", features = ["derive"] }

--- a/firefly-cardanoconnect/db/migrations/sqlite/V000007__add_operations_contract_location.sql
+++ b/firefly-cardanoconnect/db/migrations/sqlite/V000007__add_operations_contract_location.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "operations"
+ADD COLUMN "contract_address" TEXT NULL

--- a/firefly-cardanoconnect/src/contracts.rs
+++ b/firefly-cardanoconnect/src/contracts.rs
@@ -1,31 +1,39 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashMap},
+    path::PathBuf,
+    sync::Arc,
+};
 
-use anyhow::{bail, Result};
-use balius_runtime::{ledgers::Ledger, Response, Runtime, Store};
+use anyhow::{bail, Context, Result};
+use balius_runtime::{ledgers::Ledger, ChainPoint, Response, Runtime, Store};
+use dashmap::{DashMap, Entry};
 use ledger::BlockfrostLedger;
 use serde::Deserialize;
 use serde_json::{json, Value};
-use tokio::{
-    fs,
-    sync::{Mutex, RwLock},
+use tokio::{fs, sync::Mutex};
+use tracing::{error, warn};
+use u5c::convert_block;
+
+use crate::{
+    blockfrost::BlockfrostClient,
+    streams::{BlockInfo, BlockReference, Event, Listener, ListenerFilter},
 };
 
-use crate::blockfrost::BlockfrostClient;
-
 mod ledger;
+mod u5c;
 
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ContractsConfig {
     pub components_path: PathBuf,
-    pub store_path: PathBuf,
+    pub stores_path: PathBuf,
     pub cache_size: Option<usize>,
 }
 
 pub struct ContractManager {
     config: Option<ContractsConfig>,
-    blockfrost: Option<BlockfrostClient>,
-    runtime: RwLock<Option<Runtime>>,
+    ledger: Option<Ledger>,
+    runtimes: DashMap<String, Arc<Mutex<ContractRuntime>>>,
 }
 
 impl ContractManager {
@@ -34,19 +42,34 @@ impl ContractManager {
         blockfrost: Option<BlockfrostClient>,
     ) -> Result<Self> {
         fs::create_dir_all(&config.components_path).await?;
-        let runtime = Self::new_runtime(config, blockfrost.clone()).await?;
-        Ok(Self {
+        let ledger = blockfrost.map(|client| {
+            let ledger = BlockfrostLedger::new(client);
+            Ledger::Custom(Arc::new(Mutex::new(ledger)))
+        });
+        let manager = Self {
             config: Some(config.clone()),
-            blockfrost,
-            runtime: RwLock::new(Some(runtime)),
-        })
+            ledger,
+            runtimes: DashMap::new(),
+        };
+
+        let mut entries = fs::read_dir(&config.components_path).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let extless = entry.path().with_extension("");
+            let Some(contract) = extless.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if let Err(error) = manager.init_contract_runtime(contract).await {
+                warn!("Could not initialize contract {contract}: {error}");
+            }
+        }
+        Ok(manager)
     }
 
     pub fn none() -> Self {
         Self {
             config: None,
-            blockfrost: None,
-            runtime: RwLock::new(None),
+            ledger: None,
+            runtimes: DashMap::new(),
         }
     }
 
@@ -56,10 +79,7 @@ impl ContractManager {
         };
         let path = config.components_path.join(format!("{id}.wasm"));
         fs::write(&path, contract).await?;
-        let mut rt_lock = self.runtime.write().await;
-        *rt_lock = None; // drop the old worker before opening the new
-        *rt_lock = Some(Self::new_runtime(config, self.blockfrost.clone()).await?);
-        Ok(())
+        self.init_contract_runtime(id).await
     }
 
     pub async fn invoke(
@@ -68,40 +88,178 @@ impl ContractManager {
         method: &str,
         params: Value,
     ) -> Result<Option<Vec<u8>>> {
-        let params = serde_json::to_vec(&params)?;
-        let rt_lock = self.runtime.read().await;
-        let Some(runtime) = rt_lock.as_ref() else {
-            bail!("Contract manager not configured")
+        let Some(mutex) = self.runtimes.get(contract) else {
+            bail!("unrecognized contract {contract}");
         };
-        let response = runtime.handle_request(contract, method, params).await?;
+        let mut runtime = mutex.lock().await;
+        let response = runtime.invoke(method, params).await?;
         match response {
             Response::PartialTx(bytes) => Ok(Some(bytes)),
             _ => Ok(None),
         }
     }
 
-    async fn new_runtime(
-        config: &ContractsConfig,
-        blockfrost: Option<BlockfrostClient>,
-    ) -> Result<Runtime> {
-        let store = Store::open(&config.store_path, config.cache_size)?;
-        let mut runtime_builder = Runtime::builder(store);
-        if let Some(client) = blockfrost {
-            let ledger = BlockfrostLedger::new(client);
-            runtime_builder =
-                runtime_builder.with_ledger(Ledger::Custom(Arc::new(Mutex::new(ledger))))
+    pub async fn listen(&self, listener: &Listener) -> ContractListener {
+        let contracts = find_contract_names(&listener.filters);
+        let mut runtimes = vec![];
+        for contract in contracts {
+            let runtime = self.get_contract_runtime(&contract).await;
+            runtimes.push(runtime);
         }
-        let mut runtime = runtime_builder.build()?;
-        let mut entries = fs::read_dir(&config.components_path).await?;
-        while let Some(entry) = entries.next_entry().await? {
-            let extless = entry.path().with_extension("");
-            let Some(id) = extless.file_name().and_then(|s| s.to_str()) else {
-                bail!("invalid file name {:?}", entry.file_name().into_string());
-            };
-            let wasm_path = entry.path();
+        ContractListener {
+            runtimes,
+            cache: HashMap::new(),
+        }
+    }
 
-            runtime.register_worker(id, wasm_path, json!(null)).await?;
+    async fn get_contract_runtime(&self, contract: &str) -> Arc<Mutex<ContractRuntime>> {
+        if !self.runtimes.contains_key(contract) {
+            if let Err(error) = self.init_contract_runtime(contract).await {
+                warn!("Could not init contract {contract}: {error}");
+            }
         }
+        self.runtimes.get(contract).unwrap().clone()
+    }
+
+    async fn init_contract_runtime(&self, contract: &str) -> Result<()> {
+        match self.runtimes.entry(contract.to_string()) {
+            Entry::Vacant(entry) => match self.new_runtime_for(contract).await {
+                Ok(rt) => {
+                    let runtime = ContractRuntime::new(contract, rt).await;
+                    entry.insert(Arc::new(Mutex::new(runtime)));
+                }
+                Err(err) => {
+                    entry.insert(Arc::new(Mutex::new(ContractRuntime::empty(contract))));
+                    return Err(err);
+                }
+            },
+            Entry::Occupied(entry) => {
+                let mutex = entry.into_ref();
+                let mut lock = mutex.lock().await;
+                lock.runtime = None; // drop the old runtime before creating the new one
+                lock.runtime = Some(self.new_runtime_for(contract).await?);
+            }
+        };
+        Ok(())
+    }
+
+    async fn new_runtime_for(&self, contract: &str) -> Result<Runtime> {
+        let Some(config) = self.config.as_ref() else {
+            bail!("No contract directory configured");
+        };
+        let store_path = config.stores_path.join(contract).with_extension("redb");
+        let store = Store::open(&store_path, config.cache_size)?;
+        let mut runtime_builder = Runtime::builder(store);
+        if let Some(ledger) = self.ledger.clone() {
+            runtime_builder = runtime_builder.with_ledger(ledger);
+        }
+
+        let mut runtime = runtime_builder.build()?;
+
+        let wasm_path = config.components_path.join(contract).with_extension("wasm");
+        runtime
+            .register_worker(contract, wasm_path, json!(null))
+            .await?;
+
         Ok(runtime)
     }
+}
+
+pub struct ContractListener {
+    runtimes: Vec<Arc<Mutex<ContractRuntime>>>,
+    cache: HashMap<BlockReference, Vec<Event>>,
+}
+
+impl ContractListener {
+    pub async fn gather_events(&self, rollbacks: &[BlockInfo], block: &BlockInfo) {
+        for runtime in &self.runtimes {
+            let mut lock = runtime.lock().await;
+            if let Err(error) = lock.apply(rollbacks, block).await {
+                error!("could not gather events for new blocks: {error}");
+            }
+        }
+
+        // TODO: actually gather events
+    }
+
+    pub async fn events_for(&self, block_ref: &BlockReference) -> Vec<Event> {
+        self.cache.get(block_ref).cloned().unwrap_or_default()
+    }
+}
+
+struct ContractRuntime {
+    contract: String,
+    runtime: Option<Runtime>,
+    head: BlockReference,
+}
+
+impl ContractRuntime {
+    async fn new(contract: &str, runtime: Runtime) -> Self {
+        let head = match runtime.chain_cursor().await {
+            Ok(Some(ChainPoint::Cardano(r))) => {
+                BlockReference::Point(Some(r.index), hex::encode(r.hash))
+            }
+            _ => BlockReference::Origin,
+        };
+        Self {
+            contract: contract.to_string(),
+            runtime: Some(runtime),
+            head,
+        }
+    }
+    fn empty(contract: &str) -> Self {
+        Self {
+            contract: contract.to_string(),
+            runtime: None,
+            head: BlockReference::Origin,
+        }
+    }
+
+    async fn invoke(&mut self, method: &str, params: Value) -> Result<Response> {
+        let params = serde_json::to_vec(&params)?;
+        let Some(runtime) = self.runtime.as_mut() else {
+            bail!("Contract {} failed to initialize", self.contract);
+        };
+        Ok(runtime
+            .handle_request(&self.contract, method, params)
+            .await?)
+    }
+
+    async fn apply(&mut self, rollbacks: &[BlockInfo], block: &BlockInfo) -> Result<()> {
+        let Some(runtime) = self.runtime.as_mut() else {
+            bail!("Contract {} failed to initialize", self.contract);
+        };
+
+        if rollbacks
+            .first()
+            .is_some_and(|rb| rb.as_reference() != self.head)
+        {
+            // this is a rollback from a point we're not already at, ignore it
+            return Ok(());
+        } else if block.as_reference() <= self.head {
+            // we've already advanced past this point
+            return Ok(());
+        }
+
+        let undo_blocks = rollbacks.iter().map(convert_block).collect();
+        let next_block = convert_block(block);
+        runtime
+            .handle_chain(&undo_blocks, &next_block)
+            .await
+            .context("could not apply blocks")?;
+
+        self.head = block.as_reference();
+
+        Ok(())
+    }
+}
+
+fn find_contract_names(filters: &[ListenerFilter]) -> Vec<String> {
+    let mut result = BTreeSet::new();
+    for filter in filters {
+        if let ListenerFilter::Event { contract, .. } = filter {
+            result.insert(contract.clone());
+        }
+    }
+    result.into_iter().collect()
 }

--- a/firefly-cardanoconnect/src/contracts.rs
+++ b/firefly-cardanoconnect/src/contracts.rs
@@ -99,6 +99,17 @@ impl ContractManager {
         }
     }
 
+    pub async fn handle_submit(&self, contract: &str, method: &str, tx_id: &str) {
+        let params = serde_json::json!({
+            "method": method,
+            "hash": tx_id,
+        });
+        let runtime = self.get_contract_runtime(contract).await;
+        let mut lock = runtime.lock().await;
+
+        let _: Result<_, _> = lock.invoke("__tx_submitted", params).await;
+    }
+
     pub async fn listen(&self, listener: &Listener) -> ContractListener {
         let contracts = find_contract_names(&listener.filters);
         let mut runtimes = vec![];

--- a/firefly-cardanoconnect/src/contracts.rs
+++ b/firefly-cardanoconnect/src/contracts.rs
@@ -202,7 +202,7 @@ impl ContractListener {
         for runtime in &self.runtimes {
             let mut lock = runtime.lock().await;
             if let Err(error) = lock.apply(rollbacks, block).await {
-                error!("could not gather events for new blocks: {error}");
+                error!("could not gather events for new blocks: {error:#}");
             }
         }
     }

--- a/firefly-cardanoconnect/src/contracts.rs
+++ b/firefly-cardanoconnect/src/contracts.rs
@@ -8,8 +8,8 @@ use anyhow::{bail, Result};
 use balius_runtime::{ledgers::Ledger, Response};
 use dashmap::{DashMap, Entry};
 use ledger::BlockfrostLedger;
+pub use runtime::ContractEvent;
 use runtime::ContractRuntime;
-pub use runtime::RawEvent;
 use serde::Deserialize;
 use serde_json::Value;
 use tokio::{fs, sync::Mutex};
@@ -151,7 +151,7 @@ struct ContractListenerContract {
 
 pub struct ContractListener {
     contracts: Vec<ContractListenerContract>,
-    cache: HashMap<BlockReference, Vec<RawEvent>>,
+    cache: HashMap<BlockReference, Vec<ContractEvent>>,
 }
 
 impl ContractListener {
@@ -163,7 +163,7 @@ impl ContractListener {
         }
     }
 
-    pub async fn events_for(&mut self, block_ref: &BlockReference) -> &[RawEvent] {
+    pub async fn events_for(&mut self, block_ref: &BlockReference) -> &[ContractEvent] {
         match self.cache.entry(block_ref.clone()) {
             hash_map::Entry::Occupied(entry) => entry.into_mut(),
             hash_map::Entry::Vacant(entry) => {

--- a/firefly-cardanoconnect/src/contracts.rs
+++ b/firefly-cardanoconnect/src/contracts.rs
@@ -45,6 +45,7 @@ impl ContractManager {
         blockfrost: Option<BlockfrostClient>,
     ) -> Result<Self> {
         fs::create_dir_all(&config.components_path).await?;
+        fs::create_dir_all(&config.stores_path).await?;
         let ledger = blockfrost.map(|client| {
             let ledger = BlockfrostLedger::new(client);
             Ledger::Custom(Arc::new(Mutex::new(ledger)))

--- a/firefly-cardanoconnect/src/contracts/kv.rs
+++ b/firefly-cardanoconnect/src/contracts/kv.rs
@@ -1,0 +1,87 @@
+use std::path::Path;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use balius_runtime::kv::{CustomKv, KvError, Payload};
+use tokio_rusqlite::Connection;
+
+pub struct SqliteKv {
+    conn: Connection,
+    table_name: String,
+}
+
+impl SqliteKv {
+    pub async fn new(path: &Path, contract: &str) -> Result<Self> {
+        let conn = Connection::open(path).await?;
+        let table_name = format!("kv_{}", hex::encode(contract));
+        let sql = format!(
+            "CREATE TABLE IF NOT EXISTS \"{table_name}\" (
+                \"key\" TEXT NOT NULL PRIMARY KEY,
+                \"value\" BLOB NOT NULL
+            )"
+        );
+        conn.call_unwrap(move |c| c.execute(&sql, [])).await?;
+        Ok(Self { conn, table_name })
+    }
+}
+
+#[async_trait]
+impl CustomKv for SqliteKv {
+    async fn get_value(&mut self, key: String) -> Result<Payload, KvError> {
+        let table = &self.table_name;
+        let sql = format!(
+            "SELECT \"value\"
+            FROM \"{table}\"
+            WHERE \"key\" = ?1"
+        );
+        let k = key.clone();
+        let result: Option<Payload> = self
+            .conn
+            .call_unwrap(move |c| match c.prepare_cached(&sql)?.query([k])?.next()? {
+                Some(x) => Ok(Some(x.get("value")?)),
+                None => Ok(None),
+            })
+            .await
+            .map_err(|err: rusqlite::Error| KvError::Upstream(err.to_string()))?;
+        match result {
+            Some(value) => Ok(value),
+            None => Err(KvError::NotFound(key)),
+        }
+    }
+
+    async fn set_value(&mut self, key: String, value: Payload) -> Result<(), KvError> {
+        let table = &self.table_name;
+        let sql = format!(
+            "INSERT INTO \"{table}\" (\"key\", \"value\")
+            VALUES (?1, ?2)
+            ON CONFLICT(\"key\") DO UPDATE SET \"value\" = excluded.\"value\""
+        );
+        self.conn
+            .call_unwrap(move |c| {
+                c.prepare_cached(&sql)?
+                    .execute(rusqlite::params![key, value])?;
+                Ok(())
+            })
+            .await
+            .map_err(|err: rusqlite::Error| KvError::Upstream(err.to_string()))
+    }
+
+    async fn list_values(&mut self, prefix: String) -> Result<Vec<String>, KvError> {
+        let table = &self.table_name;
+        let sql = format!(
+            "SELECT \"key\"
+            FROM \"{table}\"
+            WHERE \"key\" LIKE ?1
+            ORDER BY \"key\""
+        );
+        let result: rusqlite::Result<Vec<String>> = self
+            .conn
+            .call_unwrap(move |c| {
+                c.prepare_cached(&sql)?
+                    .query_and_then([format!("{prefix}%")], |row| row.get::<&str, String>("key"))?
+                    .collect()
+            })
+            .await;
+        result.map_err(|err| KvError::Upstream(err.to_string()))
+    }
+}

--- a/firefly-cardanoconnect/src/contracts/runtime.rs
+++ b/firefly-cardanoconnect/src/contracts/runtime.rs
@@ -1,0 +1,272 @@
+use std::{path::PathBuf, sync::Arc};
+
+use anyhow::{bail, Context as _, Result};
+use balius_runtime::{kv::Kv, ledgers::Ledger, ChainPoint, Response, Runtime, Store};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tracing::warn;
+
+use crate::streams::{BlockInfo, BlockReference};
+
+use super::{kv::SqliteKv, u5c::convert_block, ContractsConfig};
+
+#[derive(Clone)]
+pub struct ContractRuntime {
+    contract: String,
+    kv: Option<Arc<Mutex<SqliteKv>>>,
+    tx: mpsc::UnboundedSender<ContractRuntimeCommand>,
+}
+
+impl ContractRuntime {
+    pub async fn new(
+        contract: &str,
+        config: Option<&ContractsConfig>,
+        ledger: Option<Ledger>,
+    ) -> Self {
+        let runtime_config = config.map(|c| ContractRuntimeWorkerConfig {
+            store_path: c.stores_path.join(contract).with_extension("redb"),
+            wasm_path: c.components_path.join(contract).with_extension("wasm"),
+            cache_size: c.cache_size,
+        });
+        let kv = if let Some(config) = config {
+            let sqlite_path = config.stores_path.join("kv.sqlite3");
+            match SqliteKv::new(&sqlite_path, contract).await {
+                Ok(kv) => Some(Arc::new(Mutex::new(kv))),
+                Err(error) => {
+                    warn!("could not initialize sqlite db: {error:#}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let mut worker = {
+            let kv = kv.clone().map(|kv| Kv::Custom(kv));
+            ContractRuntimeWorker::new(contract, runtime_config, ledger, kv)
+        };
+        let (tx, rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            worker.run(rx).await;
+        });
+        Self {
+            contract: contract.to_string(),
+            kv,
+            tx,
+        }
+    }
+
+    pub async fn init(&self) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        if self
+            .tx
+            .send(ContractRuntimeCommand::Init { done: tx })
+            .is_err()
+        {
+            bail!("runtime for contract {} has stopped", self.contract);
+        }
+        rx.await?
+    }
+
+    pub async fn invoke(&self, method: &str, params: Value) -> Result<Response> {
+        let (tx, rx) = oneshot::channel();
+        if self
+            .tx
+            .send(ContractRuntimeCommand::Invoke {
+                method: method.to_string(),
+                params,
+                done: tx,
+            })
+            .is_err()
+        {
+            bail!("runtime for contract {} has stopped", self.contract);
+        }
+        rx.await?
+    }
+
+    pub async fn apply(&self, rollbacks: &[BlockInfo], block: &BlockInfo) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+        if self
+            .tx
+            .send(ContractRuntimeCommand::Apply {
+                rollbacks: rollbacks.to_vec(),
+                block: block.clone(),
+                done: tx,
+            })
+            .is_err()
+        {
+            bail!("runtime for contract {} has stopped", self.contract);
+        }
+        rx.await?
+    }
+
+    pub async fn events(&self, block_ref: &BlockReference) -> Result<Vec<RawEvent>> {
+        let key = match block_ref {
+            BlockReference::Origin => {
+                return Ok(vec![]);
+            }
+            BlockReference::Point(_, hash) => format!("__events_{hash}"),
+        };
+        let Some(kv) = &self.kv else {
+            bail!("No contract directory configured");
+        };
+        let mut lock = kv.lock().await;
+        let raw_events: Vec<RawEvent> = lock.get(key).await?.unwrap_or_default();
+        Ok(raw_events)
+    }
+}
+
+enum ContractRuntimeCommand {
+    Init {
+        done: oneshot::Sender<Result<()>>,
+    },
+    Invoke {
+        method: String,
+        params: Value,
+        done: oneshot::Sender<Result<Response>>,
+    },
+    Apply {
+        rollbacks: Vec<BlockInfo>,
+        block: BlockInfo,
+        done: oneshot::Sender<Result<()>>,
+    },
+}
+
+#[derive(Clone)]
+struct ContractRuntimeWorkerConfig {
+    store_path: PathBuf,
+    wasm_path: PathBuf,
+    cache_size: Option<usize>,
+}
+
+struct ContractRuntimeWorker {
+    contract: String,
+    config: Option<ContractRuntimeWorkerConfig>,
+    ledger: Option<Ledger>,
+    kv: Option<Kv>,
+    runtime: Option<Runtime>,
+    head: BlockReference,
+}
+
+impl ContractRuntimeWorker {
+    fn new(
+        contract: &str,
+        config: Option<ContractRuntimeWorkerConfig>,
+        ledger: Option<Ledger>,
+        kv: Option<Kv>,
+    ) -> Self {
+        Self {
+            contract: contract.to_string(),
+            config,
+            ledger,
+            kv,
+            runtime: None,
+            head: BlockReference::Origin,
+        }
+    }
+
+    async fn run(&mut self, mut rx: mpsc::UnboundedReceiver<ContractRuntimeCommand>) {
+        while let Some(command) = rx.recv().await {
+            match command {
+                ContractRuntimeCommand::Init { done } => {
+                    let _ = done.send(self.init_runtime().await);
+                }
+                ContractRuntimeCommand::Invoke {
+                    method,
+                    params,
+                    done,
+                } => {
+                    let _ = done.send(self.invoke(&method, params).await);
+                }
+                ContractRuntimeCommand::Apply {
+                    rollbacks,
+                    block,
+                    done,
+                } => {
+                    let _ = done.send(self.apply(&rollbacks, &block).await);
+                }
+            }
+        }
+    }
+
+    async fn init_runtime(&mut self) -> Result<()> {
+        // Drop the old runtime first, so that we don't open two redb stores to it at once
+        self.runtime.take();
+
+        let Some(config) = self.config.clone() else {
+            bail!("Missing contract configuration")
+        };
+
+        let store =
+            tokio::task::spawn_blocking(move || Store::open(&config.store_path, config.cache_size))
+                .await??;
+        let mut runtime_builder = Runtime::builder(store);
+        if let Some(ledger) = self.ledger.clone() {
+            runtime_builder = runtime_builder.with_ledger(ledger);
+        }
+        if let Some(kv) = self.kv.clone() {
+            runtime_builder = runtime_builder.with_kv(kv);
+        }
+
+        let mut runtime = runtime_builder.build()?;
+        runtime
+            .register_worker(&self.contract, config.wasm_path, json!(null))
+            .await?;
+
+        let head = match runtime.chain_cursor().await {
+            Ok(Some(ChainPoint::Cardano(r))) => {
+                BlockReference::Point(Some(r.index), hex::encode(r.hash))
+            }
+            _ => BlockReference::Origin,
+        };
+
+        self.runtime = Some(runtime);
+        self.head = head;
+        Ok(())
+    }
+
+    async fn invoke(&mut self, method: &str, params: Value) -> Result<Response> {
+        let params = serde_json::to_vec(&params)?;
+        let Some(runtime) = self.runtime.as_mut() else {
+            bail!("Contract {} failed to initialize", self.contract);
+        };
+        Ok(runtime
+            .handle_request(&self.contract, method, params)
+            .await?)
+    }
+
+    async fn apply(&mut self, rollbacks: &[BlockInfo], block: &BlockInfo) -> Result<()> {
+        let Some(runtime) = self.runtime.as_mut() else {
+            bail!("Contract {} failed to initialize", self.contract);
+        };
+
+        if rollbacks
+            .first()
+            .is_some_and(|rb| rb.as_reference() != self.head)
+        {
+            // this is a rollback from a point we're not already at, ignore it
+            return Ok(());
+        } else if block.as_reference() <= self.head {
+            // we've already advanced past this point
+            return Ok(());
+        }
+
+        let undo_blocks = rollbacks.iter().map(convert_block).collect();
+        let next_block = convert_block(block);
+        runtime
+            .handle_chain(&undo_blocks, &next_block)
+            .await
+            .context("could not apply blocks")?;
+
+        self.head = block.as_reference();
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Deserialize)]
+pub struct RawEvent {
+    pub tx_hash: Vec<u8>,
+    pub signature: String,
+    pub data: serde_json::Value,
+}

--- a/firefly-cardanoconnect/src/contracts/u5c.rs
+++ b/firefly-cardanoconnect/src/contracts/u5c.rs
@@ -1,0 +1,216 @@
+use pallas_primitives::conway;
+use pallas_traverse::ComputeHash as _;
+use utxorpc_spec::utxorpc::v1alpha::cardano;
+
+use crate::streams::BlockInfo;
+
+fn convert_plutus_data(data: conway::PlutusData) -> cardano::PlutusData {
+    let inner = match data {
+        conway::PlutusData::Constr(con) => {
+            let mut constr = cardano::Constr {
+                tag: con.tag as u32,
+                any_constructor: con.any_constructor.unwrap_or_default(),
+                ..cardano::Constr::default()
+            };
+            for field in con.fields.to_vec() {
+                constr.fields.push(convert_plutus_data(field));
+            }
+            cardano::plutus_data::PlutusData::Constr(constr)
+        }
+        conway::PlutusData::Map(map) => {
+            let mut new_map = cardano::PlutusDataMap::default();
+            for (key, value) in map.to_vec() {
+                new_map.pairs.push(cardano::PlutusDataPair {
+                    key: Some(convert_plutus_data(key)),
+                    value: Some(convert_plutus_data(value)),
+                });
+            }
+            cardano::plutus_data::PlutusData::Map(new_map)
+        }
+        conway::PlutusData::BigInt(int) => {
+            let inner = match int {
+                conway::BigInt::Int(i) => {
+                    let value: i128 = i.into();
+                    cardano::big_int::BigInt::Int(value as i64)
+                }
+                conway::BigInt::BigUInt(i) => cardano::big_int::BigInt::BigUInt(i.to_vec().into()),
+                conway::BigInt::BigNInt(i) => cardano::big_int::BigInt::BigNInt(i.to_vec().into()),
+            };
+            cardano::plutus_data::PlutusData::BigInt(cardano::BigInt {
+                big_int: Some(inner),
+            })
+        }
+        conway::PlutusData::BoundedBytes(bytes) => {
+            cardano::plutus_data::PlutusData::BoundedBytes(bytes.to_vec().into())
+        }
+        conway::PlutusData::Array(array) => {
+            let mut new_array = cardano::PlutusDataArray::default();
+            for item in array.to_vec() {
+                new_array.items.push(convert_plutus_data(item));
+            }
+            cardano::plutus_data::PlutusData::Array(new_array)
+        }
+    };
+    cardano::PlutusData {
+        plutus_data: Some(inner),
+    }
+}
+
+fn convert_native_script(script: conway::NativeScript) -> cardano::NativeScript {
+    fn convert_native_script_list(scripts: Vec<conway::NativeScript>) -> cardano::NativeScriptList {
+        let mut new_list = cardano::NativeScriptList::default();
+        for script in scripts {
+            new_list.items.push(convert_native_script(script));
+        }
+        new_list
+    }
+    use cardano::native_script::NativeScript as InnerNativeScript;
+    let inner = match script {
+        conway::NativeScript::ScriptPubkey(hash) => {
+            InnerNativeScript::ScriptPubkey(hash.to_vec().into())
+        }
+        conway::NativeScript::ScriptAll(scripts) => {
+            InnerNativeScript::ScriptAll(convert_native_script_list(scripts))
+        }
+        conway::NativeScript::ScriptAny(scripts) => {
+            InnerNativeScript::ScriptAny(convert_native_script_list(scripts))
+        }
+        conway::NativeScript::ScriptNOfK(k, scripts) => {
+            InnerNativeScript::ScriptNOfK(cardano::ScriptNOfK {
+                k,
+                scripts: scripts.into_iter().map(convert_native_script).collect(),
+            })
+        }
+        conway::NativeScript::InvalidBefore(_) => todo!(),
+        conway::NativeScript::InvalidHereafter(_) => todo!(),
+    };
+    cardano::NativeScript {
+        native_script: Some(inner),
+    }
+}
+
+fn convert_tx(bytes: &[u8]) -> cardano::Tx {
+    use pallas_primitives::{alonzo, conway};
+
+    let real_tx: conway::Tx = minicbor::decode(bytes).unwrap();
+    let mut tx = cardano::Tx::default();
+    for real_output in real_tx.transaction_body.outputs {
+        let mut output = cardano::TxOutput::default();
+        match real_output {
+            conway::PseudoTransactionOutput::Legacy(txo) => {
+                output.address = txo.address.to_vec().into();
+                if let Some(hash) = txo.datum_hash {
+                    output.datum = Some(cardano::Datum {
+                        hash: hash.to_vec().into(),
+                        ..cardano::Datum::default()
+                    });
+                }
+                match txo.amount {
+                    alonzo::Value::Coin(c) => {
+                        output.coin = c;
+                    }
+                    alonzo::Value::Multiasset(c, assets) => {
+                        output.coin = c;
+                        for (policy_id, policy_assets) in assets.iter() {
+                            let assets = policy_assets
+                                .iter()
+                                .map(|(name, amount)| cardano::Asset {
+                                    name: name.to_vec().into(),
+                                    output_coin: *amount,
+                                    ..cardano::Asset::default()
+                                })
+                                .collect();
+                            output.assets.push(cardano::Multiasset {
+                                policy_id: policy_id.to_vec().into(),
+                                assets,
+                                ..cardano::Multiasset::default()
+                            });
+                        }
+                    }
+                }
+            }
+            pallas_primitives::conway::PseudoTransactionOutput::PostAlonzo(txo) => {
+                output.address = txo.address.to_vec().into();
+                if let Some(datum_option) = txo.datum_option {
+                    let mut datum = cardano::Datum::default();
+                    match datum_option {
+                        conway::PseudoDatumOption::Hash(hash) => {
+                            datum.hash = hash.to_vec().into();
+                        }
+                        conway::PseudoDatumOption::Data(data) => {
+                            let mut cbor = vec![];
+                            minicbor::encode(&data, &mut cbor).expect("infallible");
+                            datum.hash = data.0.compute_hash().to_vec().into();
+                            datum.payload = Some(convert_plutus_data(data.0));
+                            datum.original_cbor = cbor.into();
+                        }
+                    }
+                }
+                match txo.value {
+                    conway::Value::Coin(c) => {
+                        output.coin = c;
+                    }
+                    conway::Value::Multiasset(c, assets) => {
+                        output.coin = c;
+                        for (policy_id, policy_assets) in assets.iter() {
+                            let assets = policy_assets
+                                .iter()
+                                .map(|(name, amount)| cardano::Asset {
+                                    name: name.to_vec().into(),
+                                    output_coin: amount.into(),
+                                    ..cardano::Asset::default()
+                                })
+                                .collect();
+                            output.assets.push(cardano::Multiasset {
+                                policy_id: policy_id.to_vec().into(),
+                                assets,
+                                ..cardano::Multiasset::default()
+                            });
+                        }
+                    }
+                }
+                if let Some(script) = txo.script_ref {
+                    let inner = match script.0 {
+                        conway::PseudoScript::NativeScript(script) => {
+                            cardano::script::Script::Native(convert_native_script(script))
+                        }
+                        conway::PseudoScript::PlutusV1Script(script) => {
+                            cardano::script::Script::PlutusV1(script.0.to_vec().into())
+                        }
+                        conway::PseudoScript::PlutusV2Script(script) => {
+                            cardano::script::Script::PlutusV2(script.0.to_vec().into())
+                        }
+                        conway::PseudoScript::PlutusV3Script(script) => {
+                            cardano::script::Script::PlutusV3(script.0.to_vec().into())
+                        }
+                    };
+                    output.script = Some(cardano::Script {
+                        script: Some(inner),
+                    });
+                }
+            }
+        }
+        tx.outputs.push(output);
+    }
+    tx
+}
+
+/**
+ * Convert a block in our internal format (basically the bytes on the chain)
+ * into one in balius format (mostly a list of utxorpc-formatted txos)
+ */
+pub fn convert_block(info: &BlockInfo) -> balius_runtime::Block {
+    let header = cardano::BlockHeader {
+        slot: info.block_slot.unwrap_or_default(),
+        hash: hex::decode(&info.block_hash).unwrap().into(),
+        height: info.block_height.unwrap_or_default(),
+    };
+    let body = cardano::BlockBody {
+        tx: info.transactions.iter().map(|tx| convert_tx(tx)).collect(),
+    };
+    let block = cardano::Block {
+        header: Some(header),
+        body: Some(body),
+    };
+    balius_runtime::Block::Cardano(block)
+}

--- a/firefly-cardanoconnect/src/contracts/u5c.rs
+++ b/firefly-cardanoconnect/src/contracts/u5c.rs
@@ -1,3 +1,4 @@
+use pallas_crypto::hash::Hasher;
 use pallas_primitives::conway;
 use pallas_traverse::ComputeHash as _;
 use utxorpc_spec::utxorpc::v1alpha::cardano;
@@ -93,7 +94,12 @@ fn convert_tx(bytes: &[u8]) -> cardano::Tx {
     use pallas_primitives::{alonzo, conway};
 
     let real_tx: conway::Tx = minicbor::decode(bytes).unwrap();
-    let mut tx = cardano::Tx::default();
+    let mut tx = cardano::Tx {
+        hash: Hasher::<256>::hash_cbor(&real_tx.transaction_body)
+            .to_vec()
+            .into(),
+        ..cardano::Tx::default()
+    };
     for real_output in real_tx.transaction_body.outputs {
         let mut output = cardano::TxOutput::default();
         match real_output {

--- a/firefly-cardanoconnect/src/main.rs
+++ b/firefly-cardanoconnect/src/main.rs
@@ -80,7 +80,7 @@ async fn init_state(config: &CardanoConnectConfig, mock_data: bool) -> Result<Ap
     let operation_sink = broadcast::Sender::new(1024);
     let operations = Arc::new(OperationsManager::new(
         blockchain.clone(),
-        contracts,
+        contracts.clone(),
         persistence.clone(),
         signer.clone(),
         operation_sink.clone(),
@@ -91,7 +91,7 @@ async fn init_state(config: &CardanoConnectConfig, mock_data: bool) -> Result<Ap
         operations,
         signer,
         stream_manager: Arc::new(
-            StreamManager::new(persistence, blockchain, operation_sink).await?,
+            StreamManager::new(blockchain, contracts, persistence, operation_sink).await?,
         ),
     };
 

--- a/firefly-cardanoconnect/src/operations/manager.rs
+++ b/firefly-cardanoconnect/src/operations/manager.rs
@@ -83,7 +83,9 @@ impl OperationsManager {
             }
         };
         if let Some(tx) = value {
-            op.tx_id = Some(self.submit_transaction(from, tx).await?);
+            let tx_id = self.submit_transaction(from, tx).await?;
+            op.tx_id = Some(tx_id.clone());
+            self.contracts.handle_submit(contract, method, &tx_id).await;
         }
 
         op.status = OperationStatus::Succeeded;

--- a/firefly-cardanoconnect/src/operations/manager.rs
+++ b/firefly-cardanoconnect/src/operations/manager.rs
@@ -43,6 +43,7 @@ impl OperationsManager {
             id,
             status: OperationStatus::Pending,
             tx_id: None,
+            contract_address: Some(name.to_string()),
         };
         self.update_operation(&op).await?;
         match self.contracts.deploy(name, contract).await {
@@ -71,6 +72,7 @@ impl OperationsManager {
             id,
             status: OperationStatus::Pending,
             tx_id: None,
+            contract_address: None,
         };
         self.update_operation(&op).await?;
         let result = self.contracts.invoke(contract, method, params).await;

--- a/firefly-cardanoconnect/src/operations/types.rs
+++ b/firefly-cardanoconnect/src/operations/types.rs
@@ -9,6 +9,7 @@ pub struct Operation {
     pub id: OperationId,
     pub status: OperationStatus,
     pub tx_id: Option<String>,
+    pub contract_address: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/firefly-cardanoconnect/src/routes/ws.rs
+++ b/firefly-cardanoconnect/src/routes/ws.rs
@@ -102,6 +102,9 @@ async fn send_operation(socket: &mut WebSocket, op: Operation) -> Result<()> {
         },
         transaction_hash: op.tx_id.clone(),
         error_message: op.status.error_message().map(|m| m.to_string()),
+        contract_location: op
+            .contract_address
+            .map(|address| ContractLocation { address }),
     };
     let outgoing_json = serde_json::to_string(&operation)?;
     socket.send(Message::Text(outgoing_json.into())).await?;
@@ -195,6 +198,7 @@ struct OutgoingOperation {
     headers: OperationHeaders,
     transaction_hash: Option<String>,
     error_message: Option<String>,
+    contract_location: Option<ContractLocation>,
 }
 
 #[derive(Debug, Serialize)]
@@ -203,6 +207,11 @@ struct OperationHeaders {
     request_id: String,
     #[serde(rename = "type")]
     type_: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ContractLocation {
+    address: String,
 }
 
 pub async fn handle_socket_upgrade(

--- a/firefly-cardanoconnect/src/routes/ws.rs
+++ b/firefly-cardanoconnect/src/routes/ws.rs
@@ -49,6 +49,7 @@ async fn send_batch(socket: &mut WebSocket, topic: &str, batch: Batch) -> Result
             .iter()
             .map(|e| Event {
                 listener_id: Some(e.id.listener_id.clone().into()),
+                address: e.id.address.clone(),
                 signature: e.id.signature.clone(),
                 block_number: e.id.block_number,
                 block_hash: e.id.block_hash.clone(),
@@ -170,6 +171,7 @@ async fn read_message(socket: &mut WebSocket) -> Result<Option<IncomingMessage>>
 #[serde(rename_all = "camelCase")]
 struct Event {
     listener_id: Option<String>,
+    address: Option<String>,
     signature: String,
     block_hash: String,
     block_number: Option<u64>,

--- a/firefly-cardanoconnect/src/routes/ws.rs
+++ b/firefly-cardanoconnect/src/routes/ws.rs
@@ -83,6 +83,9 @@ async fn send_batch(socket: &mut WebSocket, topic: &str, batch: Batch) -> Result
             }
             error!("client couldn't process batch: {}", err.message);
         }
+        IncomingMessage::ListenReplies => {
+            // do nothing, we already send replies whether they ask or not
+        }
         other => {
             bail!("unexpected response to batch! {:?}", other);
         }
@@ -135,9 +138,10 @@ struct ErrorMessage {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[serde(tag = "type", rename_all = "lowercase")]
 enum IncomingMessage {
     Listen(ListenMessage),
+    ListenReplies,
     Ack(AckMessage),
     Error(ErrorMessage),
 }

--- a/firefly-cardanoconnect/src/streams/events.rs
+++ b/firefly-cardanoconnect/src/streams/events.rs
@@ -2,30 +2,41 @@ use std::{collections::HashMap, time::SystemTime};
 
 use serde_json::json;
 
+use crate::contracts::ContractListener;
+
 use super::{
     blockchain::{ChainListener, ListenerEvent},
     BlockInfo, BlockReference, Event, EventId, EventReference, ListenerFilter, ListenerId,
 };
 
-#[derive(Debug)]
 pub struct ChainEventStream {
     id: ListenerId,
     filters: Vec<ListenerFilter>,
     sync: ChainListener,
+    contract: ContractListener,
     cache: HashMap<BlockReference, Vec<(EventReference, Event)>>,
 }
 
 impl ChainEventStream {
-    pub fn new(id: ListenerId, filters: Vec<ListenerFilter>, sync: ChainListener) -> Self {
+    pub fn new(
+        id: ListenerId,
+        filters: Vec<ListenerFilter>,
+        sync: ChainListener,
+        contract: ContractListener,
+    ) -> Self {
         Self {
             id,
             filters,
             sync,
+            contract,
             cache: HashMap::new(),
         }
     }
 
-    pub fn try_get_next_event(&mut self, hwm: &EventReference) -> Option<(EventReference, Event)> {
+    pub async fn try_get_next_event(
+        &mut self,
+        hwm: &EventReference,
+    ) -> Option<(EventReference, Event)> {
         let mut next_hwm = hwm.clone();
         loop {
             if let Some(result) = self.next_event_in_memory(&next_hwm) {
@@ -33,7 +44,7 @@ impl ChainEventStream {
             }
             let (rollbacks, block) = self.try_get_next_block(&next_hwm.block)?;
             let block_ref = block.as_reference();
-            if let Some(event) = self.collect_events(rollbacks, block) {
+            if let Some(event) = self.collect_events(rollbacks, block).await {
                 return Some(event);
             }
             next_hwm = EventReference {
@@ -53,7 +64,7 @@ impl ChainEventStream {
             }
             let (rollbacks, block) = self.wait_for_next_block(&next_hwm.block).await;
             let block_ref = block.as_reference();
-            if let Some(event) = self.collect_events(rollbacks, block) {
+            if let Some(event) = self.collect_events(rollbacks, block).await {
                 return event;
             }
             next_hwm = EventReference {
@@ -113,35 +124,45 @@ impl ChainEventStream {
         }
     }
 
-    fn collect_events(
+    async fn collect_events(
         &mut self,
         rollbacks: Vec<BlockInfo>,
         block: BlockInfo,
     ) -> Option<(EventReference, Event)> {
+        if self.cache.contains_key(&block.as_reference()) {
+            // we already gathered these events
+            return None;
+        }
+        self.contract.gather_events(&rollbacks, &block).await;
         let mut result = None;
         for rollback in rollbacks {
-            let Some(forwards) = self.cache.get(&rollback.as_reference()) else {
-                continue;
-            };
-            let backwards: Vec<_> = forwards
-                .iter()
-                .map(|(_, e)| {
-                    let event_ref = EventReference {
-                        block: block.as_reference(),
-                        rollback: true,
-                        tx_index: Some(e.id.transaction_index),
-                        log_index: Some(e.id.log_index),
-                    };
-                    let event = e.clone().into_rollback();
-                    (event_ref, event)
-                })
-                .collect();
+            let rollback_ref = rollback.as_reference();
+            let mut backwards = self.collect_backward_tx_events(&rollback);
+            for event in self.contract.events_for(&rollback_ref).await {
+                let event_ref = EventReference {
+                    block: rollback_ref.clone(),
+                    rollback: true,
+                    tx_index: Some(event.id.transaction_index),
+                    log_index: Some(event.id.log_index),
+                };
+                backwards.push((event_ref, event));
+            }
             result = result.or(backwards.first().cloned());
-            self.cache.insert(rollback.as_reference(), backwards);
+            self.cache.insert(rollback_ref, backwards);
         }
-        let events = self.collect_forward_tx_events(&block);
+        let block_ref = block.as_reference();
+        let mut events = self.collect_forward_tx_events(&block);
+        for event in self.contract.events_for(&block_ref).await {
+            let event_ref = EventReference {
+                block: block_ref.clone(),
+                rollback: false,
+                tx_index: Some(event.id.transaction_index),
+                log_index: Some(event.id.log_index),
+            };
+            events.push((event_ref, event));
+        }
         result = result.or(events.first().cloned());
-        self.cache.insert(block.as_reference(), events);
+        self.cache.insert(block_ref, events);
         result
     }
 
@@ -176,9 +197,42 @@ impl ChainEventStream {
         events
     }
 
+    fn collect_backward_tx_events(&self, block: &BlockInfo) -> Vec<(EventReference, Event)> {
+        let mut events = vec![];
+        for (tx_idx, tx_hash) in block.transaction_hashes.iter().enumerate().rev() {
+            let tx_idx = tx_idx as u64;
+            if self.matches_tx_filter(tx_hash) {
+                let id = EventId {
+                    listener_id: self.id.clone(),
+                    signature: "TransactionRolledBack(string, string, string)".into(),
+                    block_hash: block.block_hash.clone(),
+                    block_number: block.block_height,
+                    transaction_hash: tx_hash.clone(),
+                    transaction_index: tx_idx,
+                    log_index: 0,
+                    timestamp: Some(SystemTime::now()),
+                };
+                let event = Event {
+                    id,
+                    data: json!({}),
+                };
+                let event_ref = EventReference {
+                    block: block.as_reference(),
+                    rollback: false,
+                    tx_index: Some(tx_idx),
+                    log_index: Some(0),
+                };
+                events.push((event_ref, event));
+            }
+        }
+        events
+    }
+
     fn matches_tx_filter(&self, tx_hash: &str) -> bool {
         for filter in &self.filters {
-            let ListenerFilter::TransactionId(id) = filter;
+            let ListenerFilter::TransactionId(id) = filter else {
+                continue;
+            };
             if id == tx_hash || id == "any" {
                 return true;
             }

--- a/firefly-cardanoconnect/src/streams/events.rs
+++ b/firefly-cardanoconnect/src/streams/events.rs
@@ -157,7 +157,7 @@ impl ChainEventStream {
         let mut contract_events: HashMap<_, Vec<_>> = HashMap::new();
         for contract_event in self.contract.events_for(&block_ref).await {
             contract_events
-                .entry(hex::encode(&contract_event.tx_hash))
+                .entry(contract_event.tx_hash.clone())
                 .or_default()
                 .push(contract_event.clone());
         }
@@ -173,6 +173,7 @@ impl ChainEventStream {
 
                 let id = EventId {
                     listener_id: self.id.clone(),
+                    address: None,
                     signature: tx_event_signature.into(),
                     block_hash: block.block_hash.clone(),
                     block_number: block.block_height,
@@ -197,6 +198,7 @@ impl ChainEventStream {
             for contract_event in contract_events.remove(tx_hash).into_iter().flatten() {
                 let id = EventId {
                     listener_id: self.id.clone(),
+                    address: Some(contract_event.address),
                     signature: contract_event.signature,
                     block_hash: block.block_hash.clone(),
                     block_number: block.block_height,

--- a/firefly-cardanoconnect/src/streams/manager.rs
+++ b/firefly-cardanoconnect/src/streams/manager.rs
@@ -5,7 +5,10 @@ use firefly_server::apitypes::{ApiError, ApiResult};
 use tokio::sync::broadcast;
 use ulid::Ulid;
 
-use crate::{blockchain::BlockchainClient, operations::Operation, persistence::Persistence};
+use crate::{
+    blockchain::BlockchainClient, contracts::ContractManager, operations::Operation,
+    persistence::Persistence,
+};
 
 use super::{
     mux::{Multiplexer, StreamSubscription},
@@ -19,13 +22,14 @@ pub struct StreamManager {
 
 impl StreamManager {
     pub async fn new(
-        persistence: Arc<dyn Persistence>,
         blockchain: Arc<BlockchainClient>,
+        contracts: Arc<ContractManager>,
+        persistence: Arc<dyn Persistence>,
         operation_sink: broadcast::Sender<Operation>,
     ) -> Result<Self> {
         Ok(Self {
             persistence: persistence.clone(),
-            mux: Multiplexer::new(persistence, blockchain, operation_sink).await?,
+            mux: Multiplexer::new(blockchain, contracts, persistence, operation_sink).await?,
         })
     }
 

--- a/firefly-cardanoconnect/src/streams/mux.rs
+++ b/firefly-cardanoconnect/src/streams/mux.rs
@@ -194,7 +194,7 @@ impl StreamDispatcher {
                 stream_id: stream.id,
                 batch_size: stream.batch_size,
                 batch_timeout: stream.batch_timeout,
-                batch_number: 0,
+                batch_number: 1,
                 listeners,
                 hwms,
                 persistence,

--- a/firefly-cardanoconnect/src/streams/types.rs
+++ b/firefly-cardanoconnect/src/streams/types.rs
@@ -44,6 +44,10 @@ pub enum ListenerType {
 #[serde(rename_all = "camelCase")]
 pub enum ListenerFilter {
     TransactionId(String),
+    Event {
+        contract: String,
+        event_path: String,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -132,14 +136,4 @@ pub struct EventId {
 pub struct Event {
     pub id: EventId,
     pub data: serde_json::Value,
-}
-impl Event {
-    pub fn into_rollback(mut self) -> Self {
-        if self.id.signature == "TransactionAccepted(string,string,string)" {
-            self.id.signature = "TransactionRolledBack(string,string,string)".into();
-        } else if self.id.signature == "TransactionRolledBack(string,string,string)" {
-            self.id.signature = "TransactionAccepted(string,string,string)".into();
-        }
-        self
-    }
 }

--- a/firefly-cardanoconnect/src/streams/types.rs
+++ b/firefly-cardanoconnect/src/streams/types.rs
@@ -123,6 +123,7 @@ pub struct BlockRecord {
 #[derive(Clone, Debug)]
 pub struct EventId {
     pub listener_id: ListenerId,
+    pub address: Option<String>,
     pub signature: String,
     pub block_hash: String,
     pub block_number: Option<u64>,

--- a/firefly-cardanoconnect/src/streams/types.rs
+++ b/firefly-cardanoconnect/src/streams/types.rs
@@ -44,6 +44,7 @@ pub enum ListenerType {
 #[serde(rename_all = "camelCase")]
 pub enum ListenerFilter {
     TransactionId(String),
+    #[serde(rename_all = "camelCase")]
     Event {
         contract: String,
         event_path: String,

--- a/infra/connect.yaml
+++ b/infra/connect.yaml
@@ -6,7 +6,7 @@ connector:
     network: preview
 contracts:
   componentsPath: /contracts/components
-  storePath: /contracts/store.redb
+  storesPath: /contracts/stores
 persistence:
   type: sqlite
   path: /db/db.sqlite3

--- a/scripts/demo/src/firefly.rs
+++ b/scripts/demo/src/firefly.rs
@@ -166,6 +166,7 @@ pub struct FireflyWebSocketEvent {
     pub signature: String,
     pub block_number: u64,
     pub transaction_hash: String,
+    pub data: Value,
 }
 
 #[derive(Serialize)]
@@ -246,4 +247,8 @@ pub enum ListenerType {
 #[serde(rename_all = "camelCase")]
 pub enum ListenerFilter {
     TransactionId(String),
+    Event {
+        contract: String,
+        event_path: String,
+    },
 }

--- a/scripts/demo/src/firefly.rs
+++ b/scripts/demo/src/firefly.rs
@@ -247,6 +247,7 @@ pub enum ListenerType {
 #[serde(rename_all = "camelCase")]
 pub enum ListenerFilter {
     TransactionId(String),
+    #[serde(rename_all = "camelCase")]
     Event {
         contract: String,
         event_path: String,

--- a/scripts/demo/src/main.rs
+++ b/scripts/demo/src/main.rs
@@ -167,7 +167,7 @@ async fn main() -> Result<()> {
                 if event
                     .data
                     .as_object()
-                    .and_then(|o| o.get("tx_id"))
+                    .and_then(|o| o.get("transactionId"))
                     .and_then(|id| id.as_str())
                     .is_none_or(|id| id != txid)
                 {

--- a/scripts/deploy/Cargo.toml
+++ b/scripts/deploy/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "firefly-cardano-deploy"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+hex = "0.4"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+uuid = { version = "1", features = ["v4"] }
+wat = "1"
+wit-component = "0.223"

--- a/scripts/deploy/src/clients.rs
+++ b/scripts/deploy/src/clients.rs
@@ -1,0 +1,3 @@
+mod firefly;
+
+pub use firefly::*;

--- a/scripts/deploy/src/clients/firefly.rs
+++ b/scripts/deploy/src/clients/firefly.rs
@@ -1,0 +1,134 @@
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+use reqwest::{Client, Response};
+use serde::{Deserialize, Serialize};
+
+pub struct FireflyClient {
+    client: Client,
+    base_url: String,
+}
+
+impl FireflyClient {
+    pub fn new(base_url: &str) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: format!("{base_url}/api/v1"),
+        }
+    }
+
+    pub async fn deploy_contract(&self, req: &DeployContractRequest) -> Result<ContractLocation> {
+        let url = format!("{}/contracts/deploy", self.base_url);
+        let res = self.client.post(url).json(req).send().await?;
+        let res = Self::extract_error(res).await?;
+        let body: DeployContractResponse = res.json().await?;
+        self.poll_deploy_contract_location(&body.id).await
+    }
+
+    pub async fn deploy_interface(&self, req: &ContractDefinition) -> Result<Interface> {
+        let url = format!("{}/contracts/interfaces", self.base_url);
+        let res = self.client.post(url).json(req).send().await?;
+        let res = Self::extract_error(res).await?;
+        let body: Interface = res.json().await?;
+        Ok(body)
+    }
+
+    pub async fn create_api(&self, req: &CreateApiRequest) -> Result<String> {
+        let url = format!("{}/apis", self.base_url);
+        let res = self.client.post(url).json(req).send().await?;
+        let res = Self::extract_error(res).await?;
+        let body: CreateApiResponse = res.json().await?;
+        Ok(body.urls.ui)
+    }
+
+    async fn poll_deploy_contract_location(&self, operation: &str) -> Result<ContractLocation> {
+        let url = format!("{}/operations/{operation}", self.base_url);
+        loop {
+            let res = self.client.get(&url).send().await?;
+            let res = Self::extract_error(res).await?;
+            let body: OperationStatusResponse = res.json().await?;
+            if body.status == "Failed" {
+                bail!("Contract deployment failed");
+            }
+            if body.status == "Succeeded" {
+                let Some(location) = body.output.and_then(|r| r.contract_location) else {
+                    bail!("No contract location attached to response");
+                };
+                return Ok(location);
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    async fn extract_error(res: Response) -> Result<Response> {
+        if !res.status().is_success() {
+            let default_msg = res.status().to_string();
+            let message = res.text().await.unwrap_or(default_msg);
+            bail!("request failed: {}", message);
+        }
+        Ok(res)
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeployContractRequest {
+    pub contract: String,
+    pub definition: ContractDefinition,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContractDefinition {
+    pub name: String,
+    version: String,
+    methods: Vec<serde_json::Value>,
+    events: Vec<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeployContractResponse {
+    id: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OperationStatusResponse {
+    status: String,
+    output: Option<OperationReceipt>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OperationReceipt {
+    contract_location: Option<ContractLocation>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContractLocation {
+    address: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Interface {
+    id: String,
+}
+
+#[derive(Serialize)]
+pub struct CreateApiRequest {
+    pub name: String,
+    pub location: ContractLocation,
+    pub interface: Interface,
+}
+
+#[derive(Deserialize)]
+struct CreateApiResponse {
+    urls: Urls,
+}
+
+#[derive(Deserialize)]
+struct Urls {
+    ui: String,
+}

--- a/scripts/deploy/src/contracts.rs
+++ b/scripts/deploy/src/contracts.rs
@@ -1,0 +1,54 @@
+use std::{path::Path, process::Command};
+
+use anyhow::{bail, Result};
+use wit_component::ComponentEncoder;
+
+pub fn compile(contract_path: &Path) -> Result<String> {
+    let Some(name) = contract_path.file_name() else {
+        bail!("couldn't find contract name");
+    };
+    let Some(name) = name.to_str() else {
+        bail!("invalid contract name");
+    };
+
+    println!("Compiling {name}...");
+    Command::new("cargo")
+        .arg("build")
+        .arg("--target")
+        .arg("wasm32-unknown-unknown")
+        .arg("--release")
+        .current_dir(contract_path)
+        .exec()?;
+
+    let filename = format!("{}.wasm", name.replace("-", "_"));
+    let path = contract_path
+        .join("target")
+        .join("wasm32-unknown-unknown")
+        .join("release")
+        .join(filename);
+
+    println!("Bundling {name} as WASM component...");
+    let module = wat::Parser::new().parse_file(path)?;
+    let component = ComponentEncoder::default()
+        .validate(true)
+        .module(&module)?
+        .encode()?;
+    Ok(hex::encode(&component))
+}
+
+trait CommandExt {
+    fn exec(&mut self) -> Result<()>;
+}
+
+impl CommandExt for Command {
+    fn exec(&mut self) -> Result<()> {
+        let output = self.output()?;
+        if !output.stderr.is_empty() {
+            eprintln!("{}", String::from_utf8(output.stderr)?);
+        }
+        if !output.status.success() {
+            bail!("command failed: {}", output.status);
+        }
+        Ok(())
+    }
+}

--- a/scripts/deploy/src/main.rs
+++ b/scripts/deploy/src/main.rs
@@ -1,0 +1,46 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use clients::{CreateApiRequest, DeployContractRequest, FireflyClient};
+
+mod clients;
+mod contracts;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(long)]
+    contract_path: PathBuf,
+    #[arg(long, default_value = "http://localhost:5000")]
+    firefly_url: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::try_parse()?;
+
+    let contract = contracts::compile(&args.contract_path)?;
+
+    let client = FireflyClient::new(&args.firefly_url);
+
+    let definition_path = args.contract_path.join("contract.json");
+    let definition_str =
+        std::fs::read_to_string(definition_path).context("Could not find contract.json")?;
+    let request = DeployContractRequest {
+        contract,
+        definition: serde_json::from_str(&definition_str)?,
+    };
+
+    let location = client.deploy_contract(&request).await?;
+    let interface = client.deploy_interface(&request.definition).await?;
+    let url = client
+        .create_api(&CreateApiRequest {
+            name: request.definition.name,
+            location,
+            interface,
+        })
+        .await?;
+    println!("New API available at {url}");
+
+    Ok(())
+}

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -302,6 +302,7 @@ name = "firefly-balius"
 version = "0.1.0"
 dependencies = [
  "balius-sdk",
+ "serde",
 ]
 
 [[package]]

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
 [[package]]
 name = "balius-macros"
 version = "0.1.0"
-source = "git+https://github.com/txpipe/balius.git?rev=cf2791d#cf2791d63658cd062384a11d2322480ba8f82039"
+source = "git+https://github.com/txpipe/balius.git?rev=e54ec4d#e54ec4d56a52f0f8097bb253f259fae4ecb64d34"
 dependencies = [
  "quote",
  "syn",
@@ -103,7 +103,7 @@ dependencies = [
 [[package]]
 name = "balius-sdk"
 version = "0.1.0"
-source = "git+https://github.com/txpipe/balius.git?rev=cf2791d#cf2791d63658cd062384a11d2322480ba8f82039"
+source = "git+https://github.com/txpipe/balius.git?rev=e54ec4d#e54ec4d56a52f0f8097bb253f259fae4ecb64d34"
 dependencies = [
  "balius-macros",
  "hex",
@@ -302,6 +302,7 @@ name = "firefly-balius"
 version = "0.1.0"
 dependencies = [
  "balius-sdk",
+ "hex",
  "serde",
  "serde_json",
 ]
@@ -1089,6 +1090,7 @@ version = "0.1.0"
 dependencies = [
  "balius-sdk",
  "firefly-balius",
+ "hex",
  "pallas-addresses 0.32.0",
  "pallas-traverse 0.32.0",
  "serde",

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
 [[package]]
 name = "balius-macros"
 version = "0.1.0"
-source = "git+https://github.com/txpipe/balius.git?rev=e54ec4d#e54ec4d56a52f0f8097bb253f259fae4ecb64d34"
+source = "git+https://github.com/txpipe/balius.git?rev=dd56cd0#dd56cd03ee7912762e03d83dda33f8ae93f05033"
 dependencies = [
  "quote",
  "syn",
@@ -103,7 +103,7 @@ dependencies = [
 [[package]]
 name = "balius-sdk"
 version = "0.1.0"
-source = "git+https://github.com/txpipe/balius.git?rev=e54ec4d#e54ec4d56a52f0f8097bb253f259fae4ecb64d34"
+source = "git+https://github.com/txpipe/balius.git?rev=dd56cd0#dd56cd03ee7912762e03d83dda33f8ae93f05033"
 dependencies = [
  "balius-macros",
  "hex",

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -303,6 +303,7 @@ version = "0.1.0"
 dependencies = [
  "balius-sdk",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/wasm/simple-tx/Cargo.toml
+++ b/wasm/simple-tx/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 repository = "https://github.com/SundaeSwap-finance/firefly-cardano"
 
 [dependencies]
-balius-sdk = { git = "https://github.com/txpipe/balius.git", rev = "e54ec4d" }
+balius-sdk = { git = "https://github.com/txpipe/balius.git", rev = "dd56cd0" }
 firefly-balius = { path = "../../firefly-balius" }
 hex = "0.4"
 pallas-addresses = "0.32.0"

--- a/wasm/simple-tx/Cargo.toml
+++ b/wasm/simple-tx/Cargo.toml
@@ -5,8 +5,9 @@ edition = "2021"
 repository = "https://github.com/SundaeSwap-finance/firefly-cardano"
 
 [dependencies]
-balius-sdk = { git = "https://github.com/txpipe/balius.git", rev = "cf2791d" }
+balius-sdk = { git = "https://github.com/txpipe/balius.git", rev = "e54ec4d" }
 firefly-balius = { path = "../../firefly-balius" }
+hex = "0.4"
 pallas-addresses = "0.32.0"
 pallas-traverse = "0.32.0"
 serde = { version = "1", features = ["derive"] }

--- a/wasm/simple-tx/contract.json
+++ b/wasm/simple-tx/contract.json
@@ -1,0 +1,61 @@
+{
+  "name": "simple-tx",
+  "description": "Simple TX submission contract",
+  "networkName": "simple-tx",
+  "version": "0.1.0",
+  "errors": [],
+  "methods": [
+    {
+      "description": "Sends ADA to a wallet",
+      "details": {},
+      "name": "send_ada",
+      "params": [
+        {
+          "name": "fromAddress",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "toAddress",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "amount",
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "returns": []
+    }
+  ],
+  "events": [
+    {
+      "name": "TransactionSubmitted",
+      "description": "",
+      "params": [
+        {
+          "name": "transactionId",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    {
+      "name": "TransactionFinalized",
+      "description": "",
+      "params": [
+        {
+          "name": "transactionId",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/wasm/simple-tx/src/lib.rs
+++ b/wasm/simple-tx/src/lib.rs
@@ -3,9 +3,9 @@ use balius_sdk::{
         AddressPattern, BuildError, FeeChangeReturn, OutputBuilder, TxBuilder, UtxoPattern,
         UtxoSource,
     },
-    Config, FnHandler, NewTx, Params, Worker, WorkerResult,
+    Ack, Config, FnHandler, NewTx, Params, Worker, WorkerResult,
 };
-use firefly_balius::CoinSelectionInput;
+use firefly_balius::{CoinSelectionInput, SubmittedTx, WorkerExt};
 use pallas_addresses::Address;
 use serde::Deserialize;
 
@@ -42,7 +42,15 @@ fn send_ada(_: Config<()>, req: Params<TransferRequest>) -> WorkerResult<NewTx> 
     Ok(NewTx(Box::new(tx)))
 }
 
+fn handle_submit(_: Config<()>, tx: SubmittedTx) -> WorkerResult<Ack> {
+    // TODO: track this
+    let _ = tx;
+    Ok(Ack)
+}
+
 #[balius_sdk::main]
 fn main() -> Worker {
-    Worker::new().with_request_handler("send_ada", FnHandler::from(send_ada))
+    Worker::new()
+        .with_request_handler("send_ada", FnHandler::from(send_ada))
+        .with_tx_submitted_handler(handle_submit)
 }

--- a/wasm/simple-tx/src/lib.rs
+++ b/wasm/simple-tx/src/lib.rs
@@ -21,21 +21,23 @@ struct SendAdaRequest {
 
 #[derive(Serialize)]
 struct TxSubmittedEventData {
+    #[serde(rename = "transactionId")]
     pub tx_id: String,
 }
 impl EventData for TxSubmittedEventData {
     fn signature(&self) -> String {
-        "TransactionSubmitted(String)".into()        
+        "TransactionSubmitted(string)".into()        
     }
 }
 
 #[derive(Serialize)]
 struct TxFinalizedEventData {
+    #[serde(rename = "transactionId")]
     pub tx_id: String,
 }
 impl EventData for TxFinalizedEventData {
     fn signature(&self) -> String {
-        "TransactionFinalized(String)".into()
+        "TransactionFinalized(string)".into()
     }
 }
 

--- a/wasm/simple-tx/src/lib.rs
+++ b/wasm/simple-tx/src/lib.rs
@@ -1,15 +1,15 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use balius_sdk::{
     txbuilder::{
         AddressPattern, BuildError, FeeChangeReturn, OutputBuilder, TxBuilder, UtxoPattern,
         UtxoSource,
     },
-    Ack, Config, FnHandler, NewTx, Params, Worker, WorkerResult,
+    Ack, Config, FnHandler, NewTx, Params, Utxo, Worker, WorkerResult,
 };
-use firefly_balius::{kv, CoinSelectionInput, SubmittedTx, WorkerExt};
+use firefly_balius::{emit_events, kv, CoinSelectionInput, Event, EventData, SubmittedTx, WorkerExt as _};
 use pallas_addresses::Address;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -17,6 +17,26 @@ struct SendAdaRequest {
     pub from_address: String,
     pub to_address: String,
     pub amount: u64,
+}
+
+#[derive(Serialize)]
+struct TxSubmittedEventData {
+    pub tx_id: String,
+}
+impl EventData for TxSubmittedEventData {
+    fn signature(&self) -> String {
+        "TransactionSubmitted(String)".into()        
+    }
+}
+
+#[derive(Serialize)]
+struct TxFinalizedEventData {
+    pub tx_id: String,
+}
+impl EventData for TxFinalizedEventData {
+    fn signature(&self) -> String {
+        "TransactionFinalized(String)".into()
+    }
 }
 
 fn send_ada(_: Config<()>, req: Params<SendAdaRequest>) -> WorkerResult<NewTx> {
@@ -54,9 +74,52 @@ fn handle_submit(_: Config<()>, tx: SubmittedTx) -> WorkerResult<Ack> {
     Ok(Ack)
 }
 
+fn handle_utxo(_: Config<()>, utxo: Utxo<()>) -> WorkerResult<Ack> {
+    let mut events = vec![];
+
+    // If we see a submitted block on the chain, track that we see it
+    let mut submitted_txs: HashSet<String> = kv::get("submitted_txs")?.unwrap_or_default();
+    let tx_id = hex::encode(&utxo.tx_hash);
+    if submitted_txs.remove(&tx_id) {
+        events.push(Event::new(&utxo, &TxSubmittedEventData { tx_id: tx_id.clone() })?);
+
+        kv::set("submitted_txs", &submitted_txs)?;
+        let mut pending_txs: BTreeMap<u64, Vec<String>> = kv::get("pending_txs")?.unwrap_or_default();
+        pending_txs.entry(utxo.block_height).or_default().push(tx_id.clone());
+        kv::set("pending_txs", &pending_txs)?;
+    }
+
+    // If any submitted transactions have been waiting on the chain long enough,
+    // emit an event that says they've been "finalized"
+    let mut pending_txs: BTreeMap<u64, Vec<String>> = kv::get("pending_txs")?.unwrap_or_default();
+    let mut txs_processed = false;
+    while let Some((&height, _)) = pending_txs.first_key_value() {
+        if height > utxo.block_height - 4 {
+            break;
+        }
+        txs_processed = true;
+        for tx_id in pending_txs.remove(&height).unwrap() {
+            events.push(Event::new(&utxo, &TxFinalizedEventData { tx_id: tx_id.clone() })?);
+        }
+    }
+    if txs_processed {
+        kv::set("pending_txs", &pending_txs)?;
+    }
+
+    emit_events(events)?;
+    Ok(Ack)
+}
+
 #[balius_sdk::main]
 fn main() -> Worker {
     Worker::new()
         .with_request_handler("send_ada", FnHandler::from(send_ada))
         .with_tx_submitted_handler(handle_submit)
+        .with_utxo_handler(
+            balius_sdk::wit::balius::app::driver::UtxoPattern {
+                address: None,
+                token: None,
+            },
+            FnHandler::from(handle_utxo),
+        )
 }


### PR DESCRIPTION
# Context

Add support for smart contracts which emit custom events. These events are triggered by UTXOs arriving on-chain, and can contain arbitrary JSON data.

Here's an example "finalization" event below.

![image](https://github.com/user-attachments/assets/78da24a5-865a-4c73-8d70-15a6354bdf7f)

The smart contract which emits those events lives in the ./wasm/simple-tx directory. The `deploy-contract` script can deploy it to the connector directly, and the `deploy` script can use it to create a FireFly API.

NB: we have short-term plans to produce "finalization" events automatically, since pretty much every use case will need them.
NB: the `balius` library which we use to run these "smart contracts" is under heavy development (I've been contributing!) and the API and capabilities are still evolving. 

# Important Changes Introduced

This PR completely reimplements our integration with the balius library:
 - balius contracts now listen to chainsync events (processing them at the same speed of the fastest listener)
 - balius contracts have persistence (a KV store backed by sqlite)
 - balius contracts can emit their own events! these events are stored in sqlite so they can be replayed without rerunning/rewinding the contract