### PR TITLE
Fix node-to-client support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,8 +2391,7 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bd039d7f1618d12ff348dd03eebe38c5d2a010325750e5341526c419b0f8e0"
+source = "git+https://github.com/SupernaviX/pallas.git?rev=2e9b8b0#2e9b8b08b7d8a073b483038a1baadd86e04f26b9"
 dependencies = [
  "base58",
  "bech32 0.9.1",
@@ -2434,8 +2433,7 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1584d615857c0a44058fb612e892e9e0cc47b56c3c82cdf7347b5c1d1193598c"
+source = "git+https://github.com/SupernaviX/pallas.git?rev=2e9b8b0#2e9b8b08b7d8a073b483038a1baadd86e04f26b9"
 dependencies = [
  "hex",
  "minicbor",
@@ -2479,8 +2477,7 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c1d642326ce402eb9191aeacc3dd0bf2b499848e97a56396c978a6eb9dd31a"
+source = "git+https://github.com/SupernaviX/pallas.git?rev=2e9b8b0#2e9b8b08b7d8a073b483038a1baadd86e04f26b9"
 dependencies = [
  "cryptoxide",
  "hex",
@@ -2512,8 +2509,7 @@ dependencies = [
 [[package]]
 name = "pallas-network"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e44dd876dc70cbbfc865bb9143131f57edab2c45e873d915732b81982ddb67"
+source = "git+https://github.com/SupernaviX/pallas.git?rev=2e9b8b0#2e9b8b08b7d8a073b483038a1baadd86e04f26b9"
 dependencies = [
  "byteorder",
  "hex",
@@ -2546,8 +2542,7 @@ dependencies = [
 [[package]]
 name = "pallas-primitives"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d30f5053073554d016a9f009c077f9a84275951a611cce54230de6c54d34d9b"
+source = "git+https://github.com/SupernaviX/pallas.git?rev=2e9b8b0#2e9b8b08b7d8a073b483038a1baadd86e04f26b9"
 dependencies = [
  "base58",
  "bech32 0.9.1",
@@ -2579,8 +2574,7 @@ dependencies = [
 [[package]]
 name = "pallas-traverse"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d2572d316883fe866ae648bc3c5357e70cbbe8de5d78b1246f6109520fa52f"
+source = "git+https://github.com/SupernaviX/pallas.git?rev=2e9b8b0#2e9b8b08b7d8a073b483038a1baadd86e04f26b9"
 dependencies = [
  "hex",
  "itertools 0.13.0",
@@ -2644,8 +2638,7 @@ dependencies = [
 [[package]]
 name = "pallas-wallet"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812859b4571cb53182d34094ae3ec391a25d50b0c586be5876d4d86e4eb124bc"
+source = "git+https://github.com/SupernaviX/pallas.git?rev=2e9b8b0#2e9b8b08b7d8a073b483038a1baadd86e04f26b9"
 dependencies = [
  "bech32 0.9.1",
  "bip39",

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -16,12 +16,12 @@ clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
 dashmap = "6"
 futures = "0.3"
-pallas-addresses = "0.32"
-pallas-codec = "0.32"
-pallas-crypto = "0.32"
-pallas-primitives = "0.32"
-pallas-network = "0.32"
-pallas-traverse = "0.32"
+pallas-addresses = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
+pallas-codec = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
+pallas-crypto = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
+pallas-primitives = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
+pallas-network = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
+pallas-traverse = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.25"

--- a/firefly-cardanoconnect/src/blockchain.rs
+++ b/firefly-cardanoconnect/src/blockchain.rs
@@ -1,19 +1,22 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use crate::{
-    blockfrost::BlockfrostClient,
     config::{CardanoConnectConfig, Secret},
     streams::{BlockInfo, BlockReference},
 };
 use anyhow::{bail, Result};
 use async_trait::async_trait;
+use balius_runtime::ledgers::{
+    CustomLedger, Ledger, LedgerError, TxoRef, Utxo, UtxoPage, UtxoPattern,
+};
 use blockfrost::Blockfrost;
 use mocks::MockChain;
 use n2c::NodeToClient;
 use pallas_primitives::conway::Tx;
 use pallas_traverse::wellknown::GenesisValues;
 use serde::Deserialize;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
+use utxorpc_spec::utxorpc::v1alpha::cardano::PParams;
 
 mod blockfrost;
 pub mod mocks;
@@ -81,21 +84,22 @@ pub struct BlockchainClient {
 }
 
 impl BlockchainClient {
-    pub async fn new(
-        config: &CardanoConnectConfig,
-        blockfrost: Option<BlockfrostClient>,
-    ) -> Result<Self> {
+    pub async fn new(config: &CardanoConnectConfig) -> Result<Self> {
         let blockchain = &config.connector.blockchain;
 
-        let client = match (&blockchain.socket, blockfrost) {
+        let client = match (&blockchain.socket, &blockchain.blockfrost_key) {
             (Some(socket), _) => {
-                let client =
-                    NodeToClient::new(socket, blockchain.magic(), blockchain.genesis_values())
-                        .await;
+                let client = NodeToClient::new(
+                    socket,
+                    blockchain.magic(),
+                    blockchain.era,
+                    blockchain.genesis_values(),
+                )
+                .await;
                 ClientImpl::NodeToClient(RwLock::new(client))
             }
-            (None, Some(blockfrost)) => {
-                let client = Blockfrost::new(blockfrost, blockchain.genesis_hash());
+            (None, Some(blockfrost_key)) => {
+                let client = Blockfrost::new(&blockfrost_key.0, blockchain.genesis_hash());
                 ClientImpl::Blockfrost(client)
             }
             (None, None) => bail!("Missing blockchain configuration"),
@@ -155,6 +159,21 @@ impl BlockchainClient {
         };
         Ok(ChainSyncClientWrapper { inner })
     }
+
+    pub async fn ledger(&self) -> Ledger {
+        match &self.client {
+            ClientImpl::Blockfrost(bf) => {
+                let ledger = bf.ledger();
+                Ledger::Custom(Arc::new(Mutex::new(LedgerWrapper { ledger })))
+            }
+            ClientImpl::Mock(_) => Ledger::Mock(balius_runtime::ledgers::mock::Ledger),
+            ClientImpl::NodeToClient(n2c) => {
+                let client = n2c.read().await;
+                let ledger = client.ledger();
+                Ledger::Custom(Arc::new(Mutex::new(LedgerWrapper { ledger })))
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -186,4 +205,72 @@ impl ChainSyncClient for ChainSyncClientWrapper {
 pub enum RequestNextResponse {
     RollForward(BlockInfo, #[expect(dead_code)] BlockReference),
     RollBackward(BlockReference, #[expect(dead_code)] BlockReference),
+}
+
+#[async_trait]
+trait BaliusLedger {
+    async fn get_utxos(&mut self, refs: &[TxoRef]) -> Result<Vec<Utxo>>;
+    async fn get_utxos_by_address(
+        &mut self,
+        address: Vec<u8>,
+        start: Option<String>,
+        max: usize,
+    ) -> Result<UtxoPage>;
+    async fn get_params(&mut self) -> Result<PParams>;
+}
+
+struct LedgerWrapper<T: BaliusLedger> {
+    ledger: T,
+}
+
+#[async_trait]
+impl<T: BaliusLedger + Send> CustomLedger for LedgerWrapper<T> {
+    async fn read_utxos(&mut self, mut refs: Vec<TxoRef>) -> Result<Vec<Utxo>, LedgerError> {
+        refs.sort_by(|l, r| l.tx_hash.cmp(&r.tx_hash).then(l.tx_index.cmp(&r.tx_index)));
+
+        let txos = self
+            .ledger
+            .get_utxos(&refs)
+            .await
+            .map_err(|e| LedgerError::Upstream(e.to_string()))?;
+        for (requested, found) in refs.iter().zip(txos.iter()) {
+            if found.ref_.tx_hash != requested.tx_hash || found.ref_.tx_index != requested.tx_index
+            {
+                return Err(LedgerError::NotFound(requested.clone()));
+            }
+        }
+        if refs.len() > txos.len() {
+            return Err(LedgerError::NotFound(refs.get(txos.len()).unwrap().clone()));
+        }
+        Ok(txos)
+    }
+
+    async fn read_params(&mut self) -> Result<Vec<u8>, LedgerError> {
+        let pparams = self
+            .ledger
+            .get_params()
+            .await
+            .map_err(|e| LedgerError::Upstream(e.to_string()))?;
+        serde_json::to_vec(&pparams).map_err(|e| LedgerError::Internal(e.to_string()))
+    }
+
+    async fn search_utxos(
+        &mut self,
+        pattern: UtxoPattern,
+        start: Option<String>,
+        max_items: u32,
+    ) -> Result<UtxoPage, LedgerError> {
+        if pattern.asset.is_some() {
+            return Err(LedgerError::Internal(
+                "querying by asset is not implemented".into(),
+            ));
+        }
+        let Some(address) = pattern.address else {
+            return Err(LedgerError::Internal("address is required".into()));
+        };
+        self.ledger
+            .get_utxos_by_address(address.exact_address, start, max_items as usize)
+            .await
+            .map_err(|e| LedgerError::Internal(e.to_string()))
+    }
 }

--- a/firefly-cardanoconnect/src/blockchain.rs
+++ b/firefly-cardanoconnect/src/blockchain.rs
@@ -88,15 +88,10 @@ impl BlockchainClient {
         let blockchain = &config.connector.blockchain;
 
         let client = match (&blockchain.socket, blockfrost) {
-            (Some(socket), blockfrost) => {
-                let client = NodeToClient::new(
-                    socket,
-                    blockchain.magic(),
-                    blockchain.genesis_hash(),
-                    blockchain.genesis_values(),
-                    blockfrost,
-                )
-                .await;
+            (Some(socket), _) => {
+                let client =
+                    NodeToClient::new(socket, blockchain.magic(), blockchain.genesis_values())
+                        .await;
                 ClientImpl::NodeToClient(RwLock::new(client))
             }
             (None, Some(blockfrost)) => {
@@ -169,7 +164,6 @@ pub trait ChainSyncClient {
         &mut self,
         points: &[BlockReference],
     ) -> Result<(Option<BlockReference>, BlockReference)>;
-    async fn request_block(&mut self, block_ref: &BlockReference) -> Result<Option<BlockInfo>>;
 }
 
 pub struct ChainSyncClientWrapper {
@@ -186,9 +180,6 @@ impl ChainSyncClient for ChainSyncClientWrapper {
         points: &[BlockReference],
     ) -> Result<(Option<BlockReference>, BlockReference)> {
         self.inner.find_intersect(points).await
-    }
-    async fn request_block(&mut self, block_ref: &BlockReference) -> Result<Option<BlockInfo>> {
-        self.inner.request_block(block_ref).await
     }
 }
 

--- a/firefly-cardanoconnect/src/blockchain/blockfrost.rs
+++ b/firefly-cardanoconnect/src/blockchain/blockfrost.rs
@@ -1,18 +1,12 @@
-use std::{collections::VecDeque, time::Duration};
-
-use anyhow::{bail, Context as _, Result};
-use async_trait::async_trait;
-use blockfrost_openapi::models::BlockContent;
-use futures::future::try_join_all;
+use anyhow::Result;
+use chainsync::BlockfrostChainSync;
+use client::BlockfrostClient;
+use ledger::BlockfrostLedger;
 use pallas_primitives::conway::Tx;
-use tokio::time;
 
-use crate::{
-    blockfrost::{BlockfrostClient, Pagination},
-    streams::{BlockInfo, BlockReference},
-};
-
-use super::{ChainSyncClient, RequestNextResponse};
+mod chainsync;
+mod client;
+mod ledger;
 
 pub struct Blockfrost {
     client: BlockfrostClient,
@@ -20,9 +14,9 @@ pub struct Blockfrost {
 }
 
 impl Blockfrost {
-    pub fn new(client: BlockfrostClient, genesis_hash: &str) -> Self {
+    pub fn new(key: &str, genesis_hash: &str) -> Self {
         Self {
-            client,
+            client: BlockfrostClient::new(key),
             genesis_hash: genesis_hash.to_string(),
         }
     }
@@ -39,234 +33,8 @@ impl Blockfrost {
     pub async fn open_chainsync(&self) -> Result<BlockfrostChainSync> {
         BlockfrostChainSync::new(self.client.clone(), self.genesis_hash.clone()).await
     }
-}
 
-pub struct BlockfrostChainSync {
-    client: BlockfrostClient,
-    tip: BlockContent,
-    prev: VecDeque<Point>,
-    head: Point,
-    next: VecDeque<BlockContent>,
-    genesis_hash: String,
-}
-
-#[async_trait]
-impl ChainSyncClient for BlockfrostChainSync {
-    async fn request_next(&mut self) -> Result<RequestNextResponse> {
-        if let Some(block) = self.fetch_next().await? {
-            // roll forward
-            Ok(RequestNextResponse::RollForward(
-                block,
-                parse_reference(&self.tip),
-            ))
-        } else {
-            // roll backward
-            let new_head = self.roll_back().await?;
-            Ok(RequestNextResponse::RollBackward(
-                new_head,
-                parse_reference(&self.tip),
-            ))
-        }
+    pub fn ledger(&self) -> BlockfrostLedger {
+        BlockfrostLedger::new(self.client.clone())
     }
-
-    async fn find_intersect(
-        &mut self,
-        points: &[BlockReference],
-    ) -> Result<(Option<BlockReference>, BlockReference)> {
-        self.prev.clear();
-        self.next.clear();
-        for point in points {
-            let Some(point) = self.request_point(point).await? else {
-                continue;
-            };
-
-            let history = self
-                .client
-                .blocks_previous(
-                    &point.hash,
-                    Pagination {
-                        count: 20,
-                        ..Pagination::default()
-                    },
-                )
-                .await?;
-
-            for block in history {
-                self.prev.push_back(parse_point(&block));
-            }
-            let head = point.as_reference();
-            self.head = point;
-
-            return Ok((Some(head), parse_reference(&self.tip)));
-        }
-        self.head = Point {
-            slot: None,
-            hash: self.genesis_hash.clone(),
-        };
-        Ok((None, parse_reference(&self.tip)))
-    }
-}
-
-impl BlockfrostChainSync {
-    async fn new(client: BlockfrostClient, genesis_hash: String) -> Result<Self> {
-        let tip = client.blocks_latest().await?;
-        Ok(Self {
-            client,
-            tip,
-            prev: VecDeque::new(),
-            head: Point {
-                slot: None,
-                hash: genesis_hash.clone(),
-            },
-            next: VecDeque::new(),
-            genesis_hash,
-        })
-    }
-
-    async fn fetch_next(&mut self) -> Result<Option<BlockInfo>> {
-        while self.next.is_empty() {
-            let Some(next_blocks) = self
-                .client
-                .try_blocks_next(&self.head.hash, Pagination::default())
-                .await?
-            else {
-                // our head is gone, time to roll back
-                return Ok(None);
-            };
-
-            for block in next_blocks.into_iter() {
-                self.next.push_back(block);
-            }
-
-            if let Some(latest) = self.next.back() {
-                // Update the tip if we've fetched newer blocks
-                if latest.time > self.tip.time {
-                    self.tip = latest.clone();
-                }
-            } else {
-                // If next is empty at this point, we're at the tip.
-                // We're now polling until something new appears.
-                time::sleep(Duration::from_secs(10)).await;
-            }
-        }
-
-        // We definitely have the next block to return now
-        let next = self.next.pop_front().unwrap();
-        let next = parse_block(&self.client, next).await?;
-
-        // update prev to point to the next
-        self.prev.push_back(self.head.clone());
-        self.prev.pop_front();
-        self.head = Point {
-            slot: next.block_slot,
-            hash: next.block_hash.clone(),
-        };
-
-        Ok(Some(next))
-    }
-
-    async fn roll_back(&mut self) -> Result<BlockReference> {
-        let Some(oldest) = self.prev.pop_front() else {
-            bail!("chain has rolled too far back!");
-        };
-
-        let mut new_history = self
-            .client
-            .blocks_next(&oldest.hash, Pagination::default())
-            .await?;
-        // find where history diverged
-        let split_index = new_history
-            .iter()
-            .zip(&self.prev)
-            .take_while(|(new, old)| new.hash == old.hash)
-            .count();
-        let new_next = new_history.split_off(split_index);
-
-        // everything before that point is the past
-        self.prev.clear();
-        self.prev.push_back(oldest);
-        for block in new_history {
-            self.prev.push_back(parse_point(&block));
-        }
-
-        // whatever was at that point is our new head
-        self.head = self.prev.pop_back().unwrap();
-
-        // any blocks left after that point are the future
-        self.next.clear();
-        for block in new_next {
-            self.next.push_back(block);
-        }
-
-        Ok(self.head.as_reference())
-    }
-
-    async fn request_point(&self, block_ref: &BlockReference) -> Result<Option<Point>> {
-        let (requested_slot, requested_hash) = match block_ref {
-            BlockReference::Origin => (None, &self.genesis_hash),
-            BlockReference::Point(number, hash) => (*number, hash),
-        };
-        let Some(block) = self.client.try_blocks_by_id(requested_hash).await? else {
-            return Ok(None);
-        };
-
-        if requested_slot.is_some_and(|s| block.slot.is_some_and(|b| b as u64 != s)) {
-            bail!("requested_block returned a block in the wrong slot");
-        }
-
-        Ok(Some(parse_point(&block)))
-    }
-}
-
-#[derive(Clone)]
-struct Point {
-    slot: Option<u64>,
-    hash: String,
-}
-impl Point {
-    fn as_reference(&self) -> BlockReference {
-        BlockReference::Point(self.slot, self.hash.clone())
-    }
-}
-
-fn parse_point(block: &BlockContent) -> Point {
-    Point {
-        slot: block.slot.map(|s| s as u64),
-        hash: block.hash.clone(),
-    }
-}
-
-fn parse_reference(block: &BlockContent) -> BlockReference {
-    let point = parse_point(block);
-    BlockReference::Point(point.slot, point.hash)
-}
-
-async fn parse_block(client: &BlockfrostClient, block: BlockContent) -> Result<BlockInfo> {
-    let block_hash = block.hash;
-    let block_height = block.height.map(|h| h as u64);
-    let block_slot = block.slot.map(|s| s as u64);
-
-    let transaction_hashes = client.blocks_txs(&block_hash).await?;
-
-    let tx_body_requests = transaction_hashes.iter().map(|hash| fetch_tx(client, hash));
-    let transactions = try_join_all(tx_body_requests).await?;
-
-    let info = BlockInfo {
-        block_hash,
-        block_height,
-        block_slot,
-        parent_hash: block.previous_block,
-        transaction_hashes,
-        transactions,
-    };
-    Ok(info)
-}
-
-async fn fetch_tx(blockfrost: &BlockfrostClient, hash: &str) -> Result<Vec<u8>> {
-    let tx_body = blockfrost
-        .transactions_cbor(hash)
-        .await
-        .context("could not fetch tx body")?;
-    let bytes = hex::decode(&tx_body.cbor)?;
-    Ok(bytes)
 }

--- a/firefly-cardanoconnect/src/blockchain/blockfrost/chainsync.rs
+++ b/firefly-cardanoconnect/src/blockchain/blockfrost/chainsync.rs
@@ -1,0 +1,245 @@
+use anyhow::{bail, Context as _, Result};
+use async_trait::async_trait;
+use blockfrost_openapi::models::BlockContent;
+use futures::future::try_join_all;
+use std::{collections::VecDeque, time::Duration};
+use tokio::time;
+
+use blockfrost::Pagination;
+
+use crate::{
+    blockchain::{ChainSyncClient, RequestNextResponse},
+    streams::{BlockInfo, BlockReference},
+};
+
+use super::client::BlockfrostClient;
+
+pub struct BlockfrostChainSync {
+    client: BlockfrostClient,
+    tip: BlockContent,
+    prev: VecDeque<Point>,
+    head: Point,
+    next: VecDeque<BlockContent>,
+    genesis_hash: String,
+}
+
+#[async_trait]
+impl ChainSyncClient for BlockfrostChainSync {
+    async fn request_next(&mut self) -> Result<RequestNextResponse> {
+        if let Some(block) = self.fetch_next().await? {
+            // roll forward
+            Ok(RequestNextResponse::RollForward(
+                block,
+                parse_reference(&self.tip),
+            ))
+        } else {
+            // roll backward
+            let new_head = self.roll_back().await?;
+            Ok(RequestNextResponse::RollBackward(
+                new_head,
+                parse_reference(&self.tip),
+            ))
+        }
+    }
+
+    async fn find_intersect(
+        &mut self,
+        points: &[BlockReference],
+    ) -> Result<(Option<BlockReference>, BlockReference)> {
+        self.prev.clear();
+        self.next.clear();
+        for point in points {
+            let Some(point) = self.request_point(point).await? else {
+                continue;
+            };
+
+            let history = self
+                .client
+                .blocks_previous(
+                    &point.hash,
+                    Pagination {
+                        count: 20,
+                        ..Pagination::default()
+                    },
+                )
+                .await?;
+
+            for block in history {
+                self.prev.push_back(parse_point(&block));
+            }
+            let head = point.as_reference();
+            self.head = point;
+
+            return Ok((Some(head), parse_reference(&self.tip)));
+        }
+        self.head = Point {
+            slot: None,
+            hash: self.genesis_hash.clone(),
+        };
+        Ok((None, parse_reference(&self.tip)))
+    }
+}
+
+impl BlockfrostChainSync {
+    pub async fn new(client: BlockfrostClient, genesis_hash: String) -> Result<Self> {
+        let tip = client.blocks_latest().await?;
+        Ok(Self {
+            client,
+            tip,
+            prev: VecDeque::new(),
+            head: Point {
+                slot: None,
+                hash: genesis_hash.clone(),
+            },
+            next: VecDeque::new(),
+            genesis_hash,
+        })
+    }
+
+    async fn fetch_next(&mut self) -> Result<Option<BlockInfo>> {
+        while self.next.is_empty() {
+            let Some(next_blocks) = self
+                .client
+                .try_blocks_next(&self.head.hash, Pagination::default())
+                .await?
+            else {
+                // our head is gone, time to roll back
+                return Ok(None);
+            };
+
+            for block in next_blocks.into_iter() {
+                self.next.push_back(block);
+            }
+
+            if let Some(latest) = self.next.back() {
+                // Update the tip if we've fetched newer blocks
+                if latest.time > self.tip.time {
+                    self.tip = latest.clone();
+                }
+            } else {
+                // If next is empty at this point, we're at the tip.
+                // We're now polling until something new appears.
+                time::sleep(Duration::from_secs(10)).await;
+            }
+        }
+
+        // We definitely have the next block to return now
+        let next = self.next.pop_front().unwrap();
+        let next = parse_block(&self.client, next).await?;
+
+        // update prev to point to the next
+        self.prev.push_back(self.head.clone());
+        self.prev.pop_front();
+        self.head = Point {
+            slot: next.block_slot,
+            hash: next.block_hash.clone(),
+        };
+
+        Ok(Some(next))
+    }
+
+    async fn roll_back(&mut self) -> Result<BlockReference> {
+        let Some(oldest) = self.prev.pop_front() else {
+            bail!("chain has rolled too far back!");
+        };
+
+        let mut new_history = self
+            .client
+            .blocks_next(&oldest.hash, Pagination::default())
+            .await?;
+        // find where history diverged
+        let split_index = new_history
+            .iter()
+            .zip(&self.prev)
+            .take_while(|(new, old)| new.hash == old.hash)
+            .count();
+        let new_next = new_history.split_off(split_index);
+
+        // everything before that point is the past
+        self.prev.clear();
+        self.prev.push_back(oldest);
+        for block in new_history {
+            self.prev.push_back(parse_point(&block));
+        }
+
+        // whatever was at that point is our new head
+        self.head = self.prev.pop_back().unwrap();
+
+        // any blocks left after that point are the future
+        self.next.clear();
+        for block in new_next {
+            self.next.push_back(block);
+        }
+
+        Ok(self.head.as_reference())
+    }
+
+    async fn request_point(&self, block_ref: &BlockReference) -> Result<Option<Point>> {
+        let (requested_slot, requested_hash) = match block_ref {
+            BlockReference::Origin => (None, &self.genesis_hash),
+            BlockReference::Point(number, hash) => (*number, hash),
+        };
+        let Some(block) = self.client.try_blocks_by_id(requested_hash).await? else {
+            return Ok(None);
+        };
+
+        if requested_slot.is_some_and(|s| block.slot.is_some_and(|b| b as u64 != s)) {
+            bail!("requested_block returned a block in the wrong slot");
+        }
+
+        Ok(Some(parse_point(&block)))
+    }
+}
+
+#[derive(Clone)]
+struct Point {
+    slot: Option<u64>,
+    hash: String,
+}
+impl Point {
+    fn as_reference(&self) -> BlockReference {
+        BlockReference::Point(self.slot, self.hash.clone())
+    }
+}
+
+fn parse_point(block: &BlockContent) -> Point {
+    Point {
+        slot: block.slot.map(|s| s as u64),
+        hash: block.hash.clone(),
+    }
+}
+
+fn parse_reference(block: &BlockContent) -> BlockReference {
+    let point = parse_point(block);
+    BlockReference::Point(point.slot, point.hash)
+}
+
+async fn parse_block(client: &BlockfrostClient, block: BlockContent) -> Result<BlockInfo> {
+    let block_hash = block.hash;
+    let block_height = block.height.map(|h| h as u64);
+    let block_slot = block.slot.map(|s| s as u64);
+
+    let transaction_hashes = client.blocks_txs(&block_hash).await?;
+
+    let tx_body_requests = transaction_hashes.iter().map(|hash| fetch_tx(client, hash));
+    let transactions = try_join_all(tx_body_requests).await?;
+
+    let info = BlockInfo {
+        block_hash,
+        block_height,
+        block_slot,
+        parent_hash: block.previous_block,
+        transaction_hashes,
+        transactions,
+    };
+    Ok(info)
+}
+
+async fn fetch_tx(blockfrost: &BlockfrostClient, hash: &str) -> Result<Vec<u8>> {
+    let tx_body = blockfrost
+        .transactions_cbor(hash)
+        .await
+        .context("could not fetch tx body")?;
+    let bytes = hex::decode(&tx_body.cbor)?;
+    Ok(bytes)
+}

--- a/firefly-cardanoconnect/src/blockchain/blockfrost/client.rs
+++ b/firefly-cardanoconnect/src/blockchain/blockfrost/client.rs
@@ -1,0 +1,97 @@
+use anyhow::Result;
+pub use blockfrost::Pagination;
+use blockfrost::{BlockFrostSettings, BlockfrostAPI, BlockfrostError, BlockfrostResult};
+pub use blockfrost_openapi::models::{
+    AddressUtxoContentInner, BlockContent, EpochParamContent, TxContentCbor,
+};
+
+#[derive(Debug, Clone)]
+pub struct BlockfrostClient {
+    api: BlockfrostAPI,
+}
+
+impl BlockfrostClient {
+    pub fn new(key: &str) -> Self {
+        use blockfrost::USER_AGENT;
+        let mut settings = BlockFrostSettings::new();
+        settings
+            .headers
+            .insert("User-Agent".into(), format!("{USER_AGENT} (firefly)"));
+        Self {
+            api: BlockfrostAPI::new(key, settings),
+        }
+    }
+
+    pub async fn addresses_utxos(
+        &self,
+        address: &str,
+        pagination: Pagination,
+    ) -> Result<Vec<AddressUtxoContentInner>> {
+        Ok(self.api.addresses_utxos(address, pagination).await?)
+    }
+
+    pub async fn blocks_latest(&self) -> Result<BlockContent> {
+        Ok(self.api.blocks_latest().await?)
+    }
+
+    pub async fn blocks_next(
+        &self,
+        hash: &str,
+        pagination: Pagination,
+    ) -> Result<Vec<BlockContent>> {
+        Ok(self.api.blocks_next(hash, pagination).await?)
+    }
+
+    pub async fn blocks_previous(
+        &self,
+        hash: &str,
+        pagination: Pagination,
+    ) -> Result<Vec<BlockContent>> {
+        Ok(self.api.blocks_previous(hash, pagination).await?)
+    }
+
+    pub async fn blocks_txs(&self, hash: &str) -> Result<Vec<String>> {
+        let pagination = Pagination::all();
+        Ok(self.api.blocks_txs(hash, pagination).await?)
+    }
+
+    pub async fn epochs_latest_parameters(&self) -> Result<EpochParamContent> {
+        Ok(self.api.epochs_latest_parameters().await?)
+    }
+
+    pub async fn transactions_cbor(&self, hash: &str) -> Result<TxContentCbor> {
+        Ok(self.api.transactions_cbor(hash).await?)
+    }
+
+    pub async fn transactions_submit(&self, transaction_data: Vec<u8>) -> Result<String> {
+        Ok(self.api.transactions_submit(transaction_data).await?)
+    }
+
+    pub async fn try_blocks_by_id(&self, hash: &str) -> Result<Option<BlockContent>> {
+        self.api.blocks_by_id(hash).await.none_on_404()
+    }
+
+    pub async fn try_blocks_next(
+        &self,
+        hash: &str,
+        pagination: Pagination,
+    ) -> Result<Option<Vec<BlockContent>>> {
+        self.api.blocks_next(hash, pagination).await.none_on_404()
+    }
+}
+
+trait BlockfrostResultExt {
+    type T;
+    fn none_on_404(self) -> Result<Option<Self::T>>;
+}
+
+impl<T> BlockfrostResultExt for BlockfrostResult<T> {
+    type T = T;
+    fn none_on_404(self) -> Result<Option<Self::T>> {
+        match self {
+            Err(BlockfrostError::Response { reason, .. }) if reason.status_code == 404 => Ok(None),
+            Err(error) => Err(error.into()),
+            Ok(res) => Ok(Some(res)),
+        }
+    }
+}

--- a/firefly-cardanoconnect/src/blockchain/mocks.rs
+++ b/firefly-cardanoconnect/src/blockchain/mocks.rs
@@ -65,10 +65,6 @@ impl ChainSyncClient for MockChainSync {
         let tip = chain.last().map(|b| b.as_reference()).unwrap_or_default();
         Ok((intersect.map(|i| i.as_reference()), tip))
     }
-
-    async fn request_block(&mut self, block_ref: &BlockReference) -> Result<Option<BlockInfo>> {
-        self.chain.request_block(block_ref).await
-    }
 }
 
 // Mock implementation of something which can query the chain
@@ -132,22 +128,6 @@ impl MockChain {
         }
 
         Some(final_rollback_target)
-    }
-
-    // this is a simpler version of request_range from the block fetch protocol.
-    pub async fn request_block(&self, block_ref: &BlockReference) -> Result<Option<BlockInfo>> {
-        match block_ref {
-            BlockReference::Origin => Ok(None),
-            BlockReference::Point(slot, hash) => {
-                let chain = self.chain.read().await;
-                Ok(chain
-                    .iter()
-                    .rev()
-                    .find(|b| b.block_hash == *hash)
-                    .filter(|b| b.block_slot == *slot)
-                    .cloned())
-            }
-        }
     }
 
     // TODO: roll back sometimes

--- a/firefly-cardanoconnect/src/blockchain/n2c.rs
+++ b/firefly-cardanoconnect/src/blockchain/n2c.rs
@@ -4,46 +4,43 @@ use std::{
 };
 
 use anyhow::{anyhow, bail, Context, Result};
-use async_trait::async_trait;
+use chainsync::NodeToClientChainSync;
+use ledger::NodeToClientLedger;
 use pallas_crypto::hash::Hasher;
 use pallas_network::{
     facades::NodeClient,
-    miniprotocols::{
-        chainsync::{BlockContent, NextResponse},
-        localtxsubmission::{EraTx, Response},
-        Point,
-    },
+    miniprotocols::localtxsubmission::{EraTx, Response},
 };
 use pallas_primitives::conway::Tx;
-use pallas_traverse::{wellknown::GenesisValues, MultiEraBlock, MultiEraHeader};
+use pallas_traverse::wellknown::GenesisValues;
 use tokio::time;
 use tracing::warn;
 
-use crate::{
-    streams::{BlockInfo, BlockReference},
-    utils::LazyInit,
-};
+use crate::utils::LazyInit;
 
-use super::{ChainSyncClient, RequestNextResponse};
+mod chainsync;
+mod ledger;
 
 pub struct NodeToClient {
     socket: PathBuf,
     magic: u64,
+    era: u16,
     genesis_values: GenesisValues,
     client: LazyInit<NodeClient>,
 }
 
 impl NodeToClient {
-    pub async fn new(socket: &Path, magic: u64, genesis_values: GenesisValues) -> Self {
+    pub async fn new(socket: &Path, magic: u64, era: u16, genesis_values: GenesisValues) -> Self {
         let client = Self::connect(socket, magic);
         let mut result = Self {
             socket: socket.to_path_buf(),
             magic,
+            era,
             genesis_values,
             client,
         };
         if let Err(error) = result.get_client().await {
-            warn!("cannot connect to blockfrost: {error}");
+            warn!("cannot connect to local node: {error}");
         }
         result
     }
@@ -76,18 +73,19 @@ impl NodeToClient {
         match response {
             Response::Accepted => Ok(txid),
             Response::Rejected(reason) => {
-                bail!("transaction was rejected: {}", hex::encode(&reason.0));
+                bail!("transaction was rejected: {:?}", reason);
             }
         }
     }
 
-    pub fn open_chainsync(&self) -> Result<N2cChainSync> {
+    pub fn open_chainsync(&self) -> Result<NodeToClientChainSync> {
         let client = Self::connect(&self.socket, self.magic);
         let genesis_values = self.genesis_values.clone();
-        Ok(N2cChainSync {
-            client,
-            genesis_values,
-        })
+        Ok(NodeToClientChainSync::new(client, genesis_values))
+    }
+
+    pub fn ledger(&self) -> NodeToClientLedger {
+        NodeToClientLedger::new(Self::connect(&self.socket, self.magic), self.era)
     }
 
     async fn get_client(&mut self) -> Result<&mut NodeClient> {
@@ -115,129 +113,5 @@ impl NodeToClient {
         NodeClient::connect(socket, magic)
             .await
             .context("could not connect to socket")
-    }
-}
-
-pub struct N2cChainSync {
-    client: LazyInit<NodeClient>,
-    genesis_values: GenesisValues,
-}
-
-#[async_trait]
-impl ChainSyncClient for N2cChainSync {
-    async fn request_next(&mut self) -> Result<RequestNextResponse> {
-        loop {
-            let res = self
-                .client
-                .get()
-                .await
-                .chainsync()
-                .request_or_await_next()
-                .await
-                .context("error waiting for next response")?;
-            match res {
-                NextResponse::Await => continue,
-                NextResponse::RollForward(content, tip) => {
-                    let info = self
-                        .content_to_block_info(content)
-                        .context("error parsing new block")?;
-                    let tip = point_to_block_ref(tip.0);
-                    return Ok(RequestNextResponse::RollForward(info, tip));
-                }
-                NextResponse::RollBackward(point, tip) => {
-                    let point = point_to_block_ref(point);
-                    let tip = point_to_block_ref(tip.0);
-                    return Ok(RequestNextResponse::RollBackward(point, tip));
-                }
-            };
-        }
-    }
-    async fn find_intersect(
-        &mut self,
-        points: &[BlockReference],
-    ) -> Result<(Option<BlockReference>, BlockReference)> {
-        let points = points.iter().filter_map(block_ref_to_point).collect();
-        let (intersect, tip) = self
-            .client
-            .get()
-            .await
-            .chainsync()
-            .find_intersect(points)
-            .await?;
-        let intersect = intersect.map(point_to_block_ref);
-        let tip = point_to_block_ref(tip.0);
-
-        Ok((intersect, tip))
-    }
-}
-
-impl N2cChainSync {
-    fn content_to_block_info(&self, content: BlockContent) -> Result<BlockInfo> {
-        let block = MultiEraBlock::decode(&content.0)?;
-
-        let (block_height, block_slot) = match block.header() {
-            MultiEraHeader::EpochBoundary(x) => {
-                let height = x.consensus_data.difficulty.first().cloned();
-                let slot = self
-                    .genesis_values
-                    .relative_slot_to_absolute(x.consensus_data.epoch_id, 0);
-                (height, slot)
-            }
-            MultiEraHeader::ShelleyCompatible(x) => {
-                let height = Some(x.header_body.block_number);
-                let slot = x.header_body.slot;
-                (height, slot)
-            }
-            MultiEraHeader::BabbageCompatible(x) => {
-                let height = Some(x.header_body.block_number);
-                let slot = x.header_body.slot;
-                (height, slot)
-            }
-            MultiEraHeader::Byron(x) => {
-                let height = x.consensus_data.2.first().cloned();
-                let slot = self
-                    .genesis_values
-                    .relative_slot_to_absolute(x.consensus_data.0.epoch, x.consensus_data.0.slot);
-                (height, slot)
-            }
-        };
-
-        let block_hash = hex::encode(block.hash());
-        let parent_hash = block.header().previous_hash().map(hex::encode);
-        let mut transaction_hashes = vec![];
-        let mut transactions = vec![];
-        for tx in block.txs() {
-            transaction_hashes.push(hex::encode(tx.hash()));
-            transactions.push(tx.encode());
-        }
-        let transaction_hashes = block
-            .txs()
-            .iter()
-            .map(|tx| hex::encode(tx.hash()))
-            .collect();
-        Ok(BlockInfo {
-            block_height,
-            block_slot: Some(block_slot),
-            block_hash,
-            parent_hash,
-            transaction_hashes,
-            transactions,
-        })
-    }
-}
-
-fn block_ref_to_point(block_ref: &BlockReference) -> Option<Point> {
-    match block_ref {
-        BlockReference::Origin => Some(Point::Origin),
-        BlockReference::Point(slot, hash) => {
-            Some(Point::Specific((*slot)?, hex::decode(hash).ok()?))
-        }
-    }
-}
-
-fn point_to_block_ref(point: Point) -> BlockReference {
-    match point {
-        Point::Origin => BlockReference::Origin,
-        Point::Specific(number, hash) => BlockReference::Point(Some(number), hex::encode(hash)),
     }
 }

--- a/firefly-cardanoconnect/src/blockchain/n2c/chainsync.rs
+++ b/firefly-cardanoconnect/src/blockchain/n2c/chainsync.rs
@@ -1,0 +1,149 @@
+use anyhow::{Context as _, Result};
+use async_trait::async_trait;
+use pallas_network::{
+    facades::NodeClient,
+    miniprotocols::{
+        chainsync::{BlockContent, NextResponse},
+        Point,
+    },
+};
+use pallas_traverse::{wellknown::GenesisValues, MultiEraBlock, MultiEraHeader};
+
+use crate::{
+    blockchain::{ChainSyncClient, RequestNextResponse},
+    streams::{BlockInfo, BlockReference},
+    utils::LazyInit,
+};
+
+pub struct NodeToClientChainSync {
+    client: LazyInit<NodeClient>,
+    genesis_values: GenesisValues,
+}
+
+impl NodeToClientChainSync {
+    pub fn new(client: LazyInit<NodeClient>, genesis_values: GenesisValues) -> Self {
+        Self {
+            client,
+            genesis_values,
+        }
+    }
+}
+
+#[async_trait]
+impl ChainSyncClient for NodeToClientChainSync {
+    async fn request_next(&mut self) -> Result<RequestNextResponse> {
+        loop {
+            let res = self
+                .client
+                .get()
+                .await
+                .chainsync()
+                .request_or_await_next()
+                .await
+                .context("error waiting for next response")?;
+            match res {
+                NextResponse::Await => continue,
+                NextResponse::RollForward(content, tip) => {
+                    let info = self
+                        .content_to_block_info(content)
+                        .context("error parsing new block")?;
+                    let tip = point_to_block_ref(tip.0);
+                    return Ok(RequestNextResponse::RollForward(info, tip));
+                }
+                NextResponse::RollBackward(point, tip) => {
+                    let point = point_to_block_ref(point);
+                    let tip = point_to_block_ref(tip.0);
+                    return Ok(RequestNextResponse::RollBackward(point, tip));
+                }
+            };
+        }
+    }
+    async fn find_intersect(
+        &mut self,
+        points: &[BlockReference],
+    ) -> Result<(Option<BlockReference>, BlockReference)> {
+        let points = points.iter().filter_map(block_ref_to_point).collect();
+        let (intersect, tip) = self
+            .client
+            .get()
+            .await
+            .chainsync()
+            .find_intersect(points)
+            .await?;
+        let intersect = intersect.map(point_to_block_ref);
+        let tip = point_to_block_ref(tip.0);
+
+        Ok((intersect, tip))
+    }
+}
+
+impl NodeToClientChainSync {
+    fn content_to_block_info(&self, content: BlockContent) -> Result<BlockInfo> {
+        let block = MultiEraBlock::decode(&content.0)?;
+
+        let (block_height, block_slot) = match block.header() {
+            MultiEraHeader::EpochBoundary(x) => {
+                let height = x.consensus_data.difficulty.first().cloned();
+                let slot = self
+                    .genesis_values
+                    .relative_slot_to_absolute(x.consensus_data.epoch_id, 0);
+                (height, slot)
+            }
+            MultiEraHeader::ShelleyCompatible(x) => {
+                let height = Some(x.header_body.block_number);
+                let slot = x.header_body.slot;
+                (height, slot)
+            }
+            MultiEraHeader::BabbageCompatible(x) => {
+                let height = Some(x.header_body.block_number);
+                let slot = x.header_body.slot;
+                (height, slot)
+            }
+            MultiEraHeader::Byron(x) => {
+                let height = x.consensus_data.2.first().cloned();
+                let slot = self
+                    .genesis_values
+                    .relative_slot_to_absolute(x.consensus_data.0.epoch, x.consensus_data.0.slot);
+                (height, slot)
+            }
+        };
+
+        let block_hash = hex::encode(block.hash());
+        let parent_hash = block.header().previous_hash().map(hex::encode);
+        let mut transaction_hashes = vec![];
+        let mut transactions = vec![];
+        for tx in block.txs() {
+            transaction_hashes.push(hex::encode(tx.hash()));
+            transactions.push(tx.encode());
+        }
+        let transaction_hashes = block
+            .txs()
+            .iter()
+            .map(|tx| hex::encode(tx.hash()))
+            .collect();
+        Ok(BlockInfo {
+            block_height,
+            block_slot: Some(block_slot),
+            block_hash,
+            parent_hash,
+            transaction_hashes,
+            transactions,
+        })
+    }
+}
+
+fn block_ref_to_point(block_ref: &BlockReference) -> Option<Point> {
+    match block_ref {
+        BlockReference::Origin => Some(Point::Origin),
+        BlockReference::Point(slot, hash) => {
+            Some(Point::Specific((*slot)?, hex::decode(hash).ok()?))
+        }
+    }
+}
+
+fn point_to_block_ref(point: Point) -> BlockReference {
+    match point {
+        Point::Origin => BlockReference::Origin,
+        Point::Specific(number, hash) => BlockReference::Point(Some(number), hex::encode(hash)),
+    }
+}

--- a/firefly-cardanoconnect/src/blockchain/n2c/ledger.rs
+++ b/firefly-cardanoconnect/src/blockchain/n2c/ledger.rs
@@ -1,0 +1,296 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use balius_runtime::ledgers::{TxoRef, Utxo, UtxoPage};
+use pallas_codec::utils::{CborWrap, TagWrap};
+use pallas_network::{
+    facades::NodeClient,
+    miniprotocols::localstate::{
+        self,
+        queries_v16::{
+            get_current_pparams, get_utxo_by_address, get_utxo_by_txin, RationalNumber,
+            TransactionInput, TransactionOutput, TxIns, Value,
+        },
+    },
+};
+use pallas_primitives::{alonzo, conway, Bytes, NonEmptyKeyValuePairs, PositiveCoin};
+use utxorpc_spec::utxorpc::v1alpha::cardano::{
+    CostModel, CostModels, ExPrices, ExUnits, PParams, ProtocolVersion,
+};
+
+use crate::{blockchain::BaliusLedger, utils::LazyInit};
+
+pub struct NodeToClientLedger {
+    client: LazyInit<NodeClient>,
+    era: u16,
+}
+
+impl NodeToClientLedger {
+    pub fn new(client: LazyInit<NodeClient>, era: u16) -> Self {
+        Self { client, era }
+    }
+
+    async fn query_client(&mut self) -> Result<(&mut localstate::Client, u16)> {
+        let client = self.client.get().await;
+        let query = client.statequery();
+        query.acquire(None).await?;
+        Ok((query, self.era))
+    }
+}
+
+#[async_trait]
+impl BaliusLedger for NodeToClientLedger {
+    async fn get_utxos(&mut self, refs: &[TxoRef]) -> Result<Vec<Utxo>> {
+        let mut txins = TxIns::new();
+        for ref_ in refs {
+            txins.insert(TransactionInput {
+                transaction_id: ref_.tx_hash[..].into(),
+                index: ref_.tx_index as u64,
+            });
+        }
+
+        let txos = {
+            let (query, era) = self.query_client().await?;
+            let result = get_utxo_by_txin(query, era, txins).await;
+            query.send_release().await?;
+            result?
+        };
+
+        let mut result = vec![];
+        for (address, output) in txos.iter() {
+            let body = encode_transaction_output(output)?;
+            result.push(Utxo {
+                ref_: TxoRef {
+                    tx_hash: address.transaction_id.to_vec(),
+                    tx_index: u64::from(address.index) as u32,
+                },
+                body,
+            });
+        }
+        Ok(result)
+    }
+
+    async fn get_utxos_by_address(
+        &mut self,
+        address: Vec<u8>,
+        start: Option<String>,
+        max: usize,
+    ) -> Result<UtxoPage> {
+        let txos = {
+            let (query, era) = self.query_client().await?;
+            let result = get_utxo_by_address(query, era, vec![address.into()]).await;
+            query.send_release().await?;
+            result?
+        };
+
+        let start = start.and_then(|s| s.parse().ok()).unwrap_or(0usize);
+
+        let mut result = vec![];
+        let mut next_token = None;
+        for (address, output) in txos.iter().skip(start) {
+            if result.len() == max {
+                next_token = Some((start + max).to_string());
+                break;
+            }
+            let body = encode_transaction_output(output)?;
+            result.push(Utxo {
+                ref_: TxoRef {
+                    tx_hash: address.transaction_id.to_vec(),
+                    tx_index: u64::from(address.index) as u32,
+                },
+                body,
+            });
+        }
+
+        Ok(UtxoPage {
+            utxos: result,
+            next_token,
+        })
+    }
+
+    async fn get_params(&mut self) -> Result<PParams> {
+        let pparams = {
+            let (query, era) = self.query_client().await?;
+            let result = get_current_pparams(query, era).await;
+            query.send_release().await?;
+            result?
+        };
+
+        let mut result = PParams::default();
+        for param in std::iter::once(pparams) {
+            if let Some(ada) = param.ada_per_utxo_byte {
+                result.coins_per_utxo_byte = ada.into();
+            }
+            if let Some(size) = param.max_transaction_size {
+                result.max_tx_size = size as u64;
+            }
+            if let Some(a) = param.minfee_a {
+                result.min_fee_coefficient = a as u64;
+            }
+            if let Some(b) = param.minfee_b {
+                result.min_fee_constant = b as u64;
+            }
+            if let Some(size) = param.max_block_body_size {
+                result.max_block_body_size = size as u64;
+            }
+            if let Some(size) = param.max_block_header_size {
+                result.max_block_header_size = size as u64;
+            }
+            if let Some(deposit) = param.key_deposit {
+                result.stake_key_deposit = deposit.into();
+            }
+            if let Some(deposit) = param.pool_deposit {
+                result.pool_deposit = deposit.into();
+            }
+            if let Some(bound) = param.maximum_epoch {
+                result.pool_retirement_epoch_bound = bound;
+            }
+            if let Some(pools) = param.desired_number_of_stake_pools {
+                result.desired_number_of_pools = pools as u64;
+            }
+            if let Some(i) = param.pool_pledge_influence {
+                result.pool_influence = Some(map_rational(i));
+            }
+            if let Some(e) = param.expansion_rate {
+                result.monetary_expansion = Some(map_rational(e));
+            }
+            if let Some(e) = param.treasury_growth_rate {
+                result.treasury_expansion = Some(map_rational(e));
+            }
+            if let Some(c) = param.min_pool_cost {
+                result.min_pool_cost = c.into();
+            }
+            if let Some((major, minor)) = param.protocol_version {
+                result.protocol_version = Some(ProtocolVersion {
+                    major: major as u32,
+                    minor: minor as u32,
+                });
+            }
+            if let Some(s) = param.max_value_size {
+                result.max_value_size = s as u64;
+            }
+            if let Some(p) = param.collateral_percentage {
+                result.collateral_percentage = p as u64;
+            }
+            if let Some(i) = param.max_collateral_inputs {
+                result.max_collateral_inputs = i as u64;
+            }
+            if let Some(models) = param.cost_models_for_script_languages {
+                result.cost_models = Some(CostModels {
+                    plutus_v1: models.plutus_v1.map(|values| CostModel { values }),
+                    plutus_v2: models.plutus_v2.map(|values| CostModel { values }),
+                    plutus_v3: models.plutus_v3.map(|values| CostModel { values }),
+                });
+            }
+            if let Some(prices) = param.execution_costs {
+                result.prices = Some(ExPrices {
+                    steps: Some(map_rational(prices.step_price)),
+                    memory: Some(map_rational(prices.mem_price)),
+                });
+            }
+            if let Some(ex) = param.max_tx_ex_units {
+                result.max_execution_units_per_transaction = Some(ExUnits {
+                    steps: ex.steps,
+                    memory: ex.mem as u64,
+                });
+            }
+            if let Some(ex) = param.max_block_ex_units {
+                result.max_execution_units_per_block = Some(ExUnits {
+                    steps: ex.steps,
+                    memory: ex.mem as u64,
+                });
+            }
+        }
+        Ok(result)
+    }
+}
+
+fn encode_transaction_output(output: &TransactionOutput) -> Result<Vec<u8>> {
+    let txo = match output {
+        TransactionOutput::Legacy(o) => {
+            conway::TransactionOutput::Legacy(conway::LegacyTransactionOutput {
+                address: o.address.clone(),
+                amount: map_alonzo_value(&o.amount),
+                datum_hash: o.datum_hash,
+            })
+        }
+        TransactionOutput::Current(o) => {
+            conway::TransactionOutput::PostAlonzo(conway::PostAlonzoTransactionOutput {
+                address: o.address.clone(),
+                value: map_post_alonzo_value(&o.amount),
+                datum_option: o.inline_datum.as_ref().map(map_datum).transpose()?,
+                script_ref: o.script_ref.as_ref().map(map_script_ref).transpose()?,
+            })
+        }
+    };
+    let mut buffer = vec![];
+    minicbor::encode(&txo, &mut buffer).expect("infallible");
+    Ok(buffer)
+}
+
+fn map_alonzo_value(v: &Value) -> alonzo::Value {
+    match v {
+        Value::Coin(coin) => alonzo::Value::Coin(coin.into()),
+        Value::Multiasset(coin, assets) => {
+            let coin = coin.into();
+            let assets = assets
+                .clone()
+                .to_vec()
+                .into_iter()
+                .map(|(policy_id, assets)| {
+                    let assets = assets
+                        .to_vec()
+                        .into_iter()
+                        .map(|(asset_name, value)| (asset_name, value.into()))
+                        .collect();
+                    (policy_id, assets)
+                })
+                .collect();
+            alonzo::Value::Multiasset(coin, assets)
+        }
+    }
+}
+
+fn map_post_alonzo_value(v: &Value) -> conway::Value {
+    match v {
+        Value::Coin(coin) => conway::Value::Coin(coin.into()),
+        Value::Multiasset(coin, assets) => {
+            let coin = coin.into();
+            let assets = assets
+                .clone()
+                .to_vec()
+                .into_iter()
+                .filter_map(|(policy_id, assets)| {
+                    let assets = assets
+                        .to_vec()
+                        .into_iter()
+                        .filter_map(|(asset_name, value)| {
+                            let coin = PositiveCoin::try_from(u64::from(value)).ok()?;
+                            Some((asset_name, coin))
+                        })
+                        .collect();
+                    Some((policy_id, NonEmptyKeyValuePairs::from_vec(assets)?))
+                })
+                .collect();
+            if let Some(assets) = NonEmptyKeyValuePairs::from_vec(assets) {
+                conway::Value::Multiasset(coin, assets)
+            } else {
+                conway::Value::Coin(coin)
+            }
+        }
+    }
+}
+
+fn map_datum(d: &(u16, TagWrap<Bytes, 24>)) -> Result<conway::DatumOption> {
+    Ok(minicbor::decode(&d.1)?)
+}
+
+fn map_script_ref(r: &TagWrap<Bytes, 24>) -> Result<CborWrap<conway::ScriptRef>> {
+    Ok(CborWrap(minicbor::decode(&r.0)?))
+}
+
+fn map_rational(r: RationalNumber) -> utxorpc_spec::utxorpc::v1alpha::cardano::RationalNumber {
+    utxorpc_spec::utxorpc::v1alpha::cardano::RationalNumber {
+        numerator: r.numerator as i32,
+        denominator: r.denominator as u32,
+    }
+}

--- a/firefly-cardanoconnect/src/main.rs
+++ b/firefly-cardanoconnect/src/main.rs
@@ -6,7 +6,6 @@ use aide::axum::{
 };
 use anyhow::Result;
 use blockchain::BlockchainClient;
-use blockfrost::BlockfrostClient;
 use clap::Parser;
 use config::{load_config, CardanoConnectConfig};
 use contracts::ContractManager;
@@ -29,7 +28,6 @@ use tokio::sync::broadcast;
 use tracing::instrument;
 
 mod blockchain;
-mod blockfrost;
 mod config;
 mod contracts;
 mod operations;
@@ -58,21 +56,15 @@ struct AppState {
 
 #[instrument(err(Debug))]
 async fn init_state(config: &CardanoConnectConfig, mock_data: bool) -> Result<AppState> {
-    let blockfrost = config
-        .connector
-        .blockchain
-        .blockfrost_key
-        .as_ref()
-        .map(|k| BlockfrostClient::new(&k.0));
     let persistence = persistence::init(&config.persistence).await?;
     let signer = Arc::new(CardanoSigner::new(config)?);
     let blockchain = if mock_data {
         Arc::new(BlockchainClient::mock().await)
     } else {
-        Arc::new(BlockchainClient::new(config, blockfrost.clone()).await?)
+        Arc::new(BlockchainClient::new(config).await?)
     };
     let contracts = if let Some(contracts) = &config.contracts {
-        Arc::new(ContractManager::new(contracts, blockfrost).await?)
+        Arc::new(ContractManager::new(contracts, &blockchain).await?)
     } else {
         Arc::new(ContractManager::none())
     };

--- a/firefly-cardanoconnect/src/streams/blockchain.rs
+++ b/firefly-cardanoconnect/src/streams/blockchain.rs
@@ -173,6 +173,7 @@ impl ChainListenerImpl {
                 self.history.push_back(block);
             }
             ChainSyncEvent::RollBackward(rollback_to) => {
+                let rolling_back_to_start = rollback_to == self.start;
                 let target_hash = match rollback_to {
                     BlockReference::Origin => self.genesis_hash.clone(),
                     BlockReference::Point(_, hash) => hash,
@@ -192,7 +193,7 @@ impl ChainListenerImpl {
                         .insert(rolled_back.as_reference(), rolled_back);
                 }
                 assert!(
-                    !self.history.is_empty(),
+                    !self.history.is_empty() || rolling_back_to_start,
                     "tried rolling back past recorded history"
                 );
             }

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -13,10 +13,10 @@ clap = { version = "4", features = ["derive"] }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.25"
-pallas-addresses = "0.32"
-pallas-crypto = "0.32"
-pallas-primitives = "0.32"
-pallas-wallet = "0.32"
+pallas-addresses = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
+pallas-crypto = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
+pallas-primitives = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
+pallas-wallet = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
 rand = "0.8"
 schemars = "0.8"
 serde = "1"

--- a/scripts/demo/src/firefly.rs
+++ b/scripts/demo/src/firefly.rs
@@ -200,8 +200,6 @@ struct OperationStatus {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Tip {
-    #[allow(unused)]
-    pub block_height: u64,
     pub block_slot: u64,
     pub block_hash: String,
 }

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -9,8 +9,8 @@ bech32 = "0.11"
 clap = { version = "4", features = ["derive"] }
 hex = "0.4"
 minicbor = "0.25"
-pallas-crypto = "0.32"
-pallas-primitives = "0.32"
+pallas-crypto = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
+pallas-primitives = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -634,8 +634,7 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bd039d7f1618d12ff348dd03eebe38c5d2a010325750e5341526c419b0f8e0"
+source = "git+https://github.com/SupernaviX/pallas.git?rev=2e9b8b0#2e9b8b08b7d8a073b483038a1baadd86e04f26b9"
 dependencies = [
  "base58",
  "bech32",
@@ -662,8 +661,7 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1584d615857c0a44058fb612e892e9e0cc47b56c3c82cdf7347b5c1d1193598c"
+source = "git+https://github.com/SupernaviX/pallas.git?rev=2e9b8b0#2e9b8b08b7d8a073b483038a1baadd86e04f26b9"
 dependencies = [
  "hex",
  "minicbor",
@@ -689,8 +687,7 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c1d642326ce402eb9191aeacc3dd0bf2b499848e97a56396c978a6eb9dd31a"
+source = "git+https://github.com/SupernaviX/pallas.git?rev=2e9b8b0#2e9b8b08b7d8a073b483038a1baadd86e04f26b9"
 dependencies = [
  "cryptoxide",
  "hex",
@@ -720,8 +717,7 @@ dependencies = [
 [[package]]
 name = "pallas-primitives"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d30f5053073554d016a9f009c077f9a84275951a611cce54230de6c54d34d9b"
+source = "git+https://github.com/SupernaviX/pallas.git?rev=2e9b8b0#2e9b8b08b7d8a073b483038a1baadd86e04f26b9"
 dependencies = [
  "base58",
  "bech32",
@@ -753,8 +749,7 @@ dependencies = [
 [[package]]
 name = "pallas-traverse"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d2572d316883fe866ae648bc3c5357e70cbbe8de5d78b1246f6109520fa52f"
+source = "git+https://github.com/SupernaviX/pallas.git?rev=2e9b8b0#2e9b8b08b7d8a073b483038a1baadd86e04f26b9"
 dependencies = [
  "hex",
  "itertools",

--- a/wasm/simple-tx/Cargo.toml
+++ b/wasm/simple-tx/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/hyperledger/firefly-cardano"
 balius-sdk = { git = "https://github.com/txpipe/balius.git", rev = "dd56cd0" }
 firefly-balius = { path = "../../firefly-balius" }
 hex = "0.4"
-pallas-addresses = "0.32.0"
-pallas-traverse = "0.32.0"
+pallas-addresses = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
+pallas-traverse = { git = "https://github.com/SupernaviX/pallas.git", rev = "2e9b8b0" }
 serde = { version = "1", features = ["derive"] }
 
 [lib]


### PR DESCRIPTION
# Context

Fully support running the connector against a local cardano node (using Cardano's node-to-client protocol) without a blockfrost key. The connector already supported using node-to-client protocol for chainsync and tx submission, but needed to fall back to blockfrost for some essential operations.

- If `connector.blockchain.socket` is defined in config, the connector will use n2c over the socket at that path.
- Otherwise, if `connector.blockchain.blockfrostKey` is defined, the connector will run against blockfrost.
- If neither value is set, it will refuse to start.

# Important Changes Introduced

 - Remove all calls to `request_block`. The node-to-client protocol doesn't support fetching individual blocks, only staying in sync with an entire chain.
 - Support using node-to-client protocol to back the balius ledger.
 - Remove explicit blockfrost references outside of the `blockchain` module. Now blockfrost is one blockchain provider, and the rest of the connector is decoupled from it.