### PR TITLE
feat: use cardano-node directly in CI

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -14,9 +14,7 @@ jobs:
       - name: Add wallet secret
         run: mkdir ./infra/wallet ; echo '${{ secrets.DEMO_WALLET }}' > ./infra/wallet/addr_test1vqhkukz0285zvk0xrwk9jlq0075tx6furuzcjvzpnhtgelsuhhqc4.skey
       - name: Start docker-compose
-        run: docker compose -f ./infra/docker-compose.yaml -p preview up  -d --build
-        env:
-          BLOCKFROST_KEY: ${{ secrets.BLOCKFROST_KEY }}
+        run: docker compose -f ./infra/docker-compose.yaml -f ./infra/docker-compose.node.yaml -p preview up  -d --build
       - name: Add just
         uses: extractions/setup-just@v2
       - name: Set up Rust
@@ -27,7 +25,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
       - name: Logs
         run: |
-          docker compose -f ./infra/docker-compose.yaml -p preview logs
+          docker compose -f ./infra/docker-compose.yaml -f ./infra/docker-compose.node.yaml -p preview logs
           docker ps -a
       - name: Run demo
         env:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ Requires at least Docker Compose version 2.22.0, uses Compose Watch: <https://do
 The easier way to get started is to use Docker compose to build your entire cluster.
 
 ```
-# To compose a cluster
+# To compose a cluster using Blockfrost as a backing store
 BLOCKFROST_KEY=previewXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX docker compose -f infra/docker-compose.yaml up --build -d
+
+# To create a cluster with a local cardano node (takes longer to spin up)
+docker compose -f infra/docker-compose.node.yaml up --build -d
 
 # Watch the build
 docker compose watch

--- a/infra/docker-compose.common.yaml
+++ b/infra/docker-compose.common.yaml
@@ -1,0 +1,59 @@
+services:
+  firefly-core:
+    image: ghcr.io/gytis-ivaskevicius/firefly-core:latest
+    volumes:
+      - ./firefly-core.yaml:/etc/firefly/firefly.core.yml:ro
+    ports:
+      - 5000:5000
+      - 5101:5101
+    depends_on:
+      firefly-cardanoconnect:
+          condition: service_started
+      firefly-cardanosigner:
+          condition: service_started
+      postgres:
+          condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - curl
+        - --fail
+        - http://localhost:5000/api/v1/status
+      interval: 15s
+      retries: 30
+
+  postgres:
+    image: postgres
+    environment:
+        PGDATA: /var/lib/postgresql/data/pgdata
+        POSTGRES_PASSWORD: f1refly
+    volumes:
+        - firefly-db:/var/lib/postgresql/data
+    ports:
+        - 5104:5432
+    healthcheck:
+        test:
+            - CMD-SHELL
+            - pg_isready -U postgres
+        interval: 5s
+        timeout: 3s
+        retries: 12
+
+  firefly-cardanosigner:
+    image: ghcr.io/hyperledger/firefly-cardanosigner:main
+    build:
+      context: ..
+      target: firefly-cardanosigner
+    develop:
+      watch:
+      - action: rebuild
+        path: ../firefly-cardanosigner
+    command: ./firefly-cardanosigner --config-file /app/config.yaml
+    ports:
+      - 8555:8555
+    volumes:
+      - ./wallet:/wallet
+      - ./signer.yaml:/app/config.yaml
+
+volumes:
+  firefly-db:

--- a/infra/docker-compose.node.yaml
+++ b/infra/docker-compose.node.yaml
@@ -1,6 +1,8 @@
+include:
+  - docker-compose.common.yaml
 services:
   init-node:
-    image: ghcr.io/input-output-hk/mithril-client:2450.0-c6c7eba
+    image: ghcr.io/input-output-hk/mithril-client:2506.0-2627f17
     entrypoint: /app/bin/entrypoint.sh
     user: "${UID}:${GID}"
     environment:
@@ -25,6 +27,26 @@ services:
     depends_on:
       init-node:
         condition: service_completed_successfully
+
+  firefly-cardanoconnect:
+    image: ghcr.io/hyperledger/firefly-cardanoconnect:main
+    build:
+      context: ..
+      target: firefly-cardanoconnect
+    develop:
+      watch:
+      - action: rebuild
+        path: ../firefly-cardanoconnect
+    command: ./firefly-cardanoconnect --config-file ./config.yaml
+    environment:
+      - FIREFLY_CONNECTOR_BLOCKCHAIN_SOCKET=/ipc/node.socket
+    ports:
+      - 5018:5018
+    volumes:
+      - connect-contracts:/contracts
+      - connect-db:/db
+      - ./connect.yaml:/app/config.yaml
+      - ./ipc:/ipc
 
 volumes:
   node-db:

--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -1,44 +1,6 @@
+include:
+  - docker-compose.common.yaml
 services:
-  firefly-core:
-    image: ghcr.io/gytis-ivaskevicius/firefly-core:latest
-    volumes:
-      - ./firefly-core.yaml:/etc/firefly/firefly.core.yml:ro
-    ports:
-      - 5000:5000
-      - 5101:5101
-    depends_on:
-      firefly-cardanoconnect:
-          condition: service_started
-      firefly-cardanosigner:
-          condition: service_started
-      postgres:
-          condition: service_healthy
-    healthcheck:
-      test:
-        - CMD
-        - curl
-        - --fail
-        - http://localhost:5000/api/v1/status
-      interval: 15s
-      retries: 30
-
-  postgres:
-    image: postgres
-    environment:
-        PGDATA: /var/lib/postgresql/data/pgdata
-        POSTGRES_PASSWORD: f1refly
-    volumes:
-        - firefly-db:/var/lib/postgresql/data
-    ports:
-        - 5104:5432
-    healthcheck:
-        test:
-            - CMD-SHELL
-            - pg_isready -U postgres
-        interval: 5s
-        timeout: 3s
-        retries: 12
-
   firefly-cardanoconnect:
     image: ghcr.io/hyperledger/firefly-cardanoconnect:main
     build:
@@ -58,23 +20,6 @@ services:
       - connect-db:/db
       - ./connect.yaml:/app/config.yaml
 
-  firefly-cardanosigner:
-    image: ghcr.io/hyperledger/firefly-cardanosigner:main
-    build:
-      context: ..
-      target: firefly-cardanosigner
-    develop:
-      watch:
-      - action: rebuild
-        path: ../firefly-cardanosigner
-    command: ./firefly-cardanosigner --config-file /app/config.yaml
-    ports:
-      - 8555:8555
-    volumes:
-      - ./wallet:/wallet
-      - ./signer.yaml:/app/config.yaml
-
 volumes:
   connect-contracts:
   connect-db:
-  firefly-db:

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 deploy-contract:
-  cargo run -p firefly-cardano-deploy-contract -- --contract-path ./wasm/simple-tx --firefly-url http://localhost:5000
+  cargo run -p firefly-cardano-deploy-contract -- --contract-path ./wasm/simple-tx
 demo: deploy-contract
   cargo run -p firefly-cardano-demo -- --addr-from $ADDR_FROM --addr-to $ADDR_TO --amount 1000000
 generate-key:


### PR DESCRIPTION
# Context

Update the demo job to spin up a fresh preview docker-compose for every test, and use that instead of a blockfrost key. This removes the outside CI dependency on something potentially subject to rate limiting, making sure builds stay stable.