### PR TITLE
Contracts query endpoint

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Add wasm32-unknown-unknown target
         run: rustup target add wasm32-unknown-unknown
       - name: Logs
+        if: always()
         run: |
           docker compose -f ./infra/docker-compose.node.yaml -p preview logs
           docker ps -a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-balius"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "balius-sdk",
  "hex",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-demo"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-deploy"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-deploy-contract"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-generate-key"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardanoconnect"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aide",
  "anyhow",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardanosigner"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aide",
  "anyhow",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-server"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aide",
  "anyhow",

--- a/firefly-balius/Cargo.toml
+++ b/firefly-balius/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-balius"
-version = "0.2.1"
+version = "0.3.0"
 description = "Helpers to write contracts for the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardanoconnect"
-version = "0.2.1"
+version = "0.3.0"
 description = "An implementation of the FireFly Connector API for Cardano"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanoconnect/src/main.rs
+++ b/firefly-cardanoconnect/src/main.rs
@@ -14,7 +14,7 @@ use operations::OperationsManager;
 use routes::{
     chain::get_chain_tip,
     health::health,
-    operations::{deploy_contract, get_operation_status, invoke_contract},
+    operations::{deploy_contract, get_operation_status, invoke_contract, query_contract},
     streams::{
         create_listener, create_stream, delete_listener, delete_stream, get_listener, get_stream,
         list_listeners, list_streams, update_stream,
@@ -104,6 +104,7 @@ async fn main() -> Result<()> {
         .api_route("/health", get(health))
         .api_route("/contracts/deploy", post(deploy_contract))
         .api_route("/contracts/invoke", post(invoke_contract))
+        .api_route("/contracts/query", post(query_contract))
         .api_route("/transactions", post(submit_transaction))
         .api_route("/transactions/{id}", get(get_operation_status))
         .api_route("/eventstreams", post(create_stream).get(list_streams))

--- a/firefly-cardanoconnect/src/operations/manager.rs
+++ b/firefly-cardanoconnect/src/operations/manager.rs
@@ -96,6 +96,10 @@ impl OperationsManager {
         Ok(())
     }
 
+    pub async fn query(&self, contract: &str, method: &str, params: Value) -> ApiResult<Value> {
+        Ok(self.contracts.query(contract, method, params).await?)
+    }
+
     pub async fn get_operation(&self, id: &OperationId) -> ApiResult<Operation> {
         let Some(op) = self.persistence.read_operation(id).await? else {
             return Err(ApiError::not_found("No operation found with that id"));

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardanosigner"
-version = "0.2.1"
+version = "0.3.0"
 description = "A service managing keys and signing for the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/firefly-server/Cargo.toml
+++ b/firefly-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-server"
-version = "0.2.1"
+version = "0.3.0"
 description = "Internal library with shared code for services"
 license-file.workspace = true
 publish = false

--- a/scripts/demo/Cargo.toml
+++ b/scripts/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-demo"
-version = "0.2.1"
+version = "0.3.0"
 description = "A demo of the firefly-cardanoconnect API"
 license-file.workspace = true
 publish = false

--- a/scripts/deploy-contract/Cargo.toml
+++ b/scripts/deploy-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-deploy-contract"
-version = "0.2.1"
+version = "0.3.0"
 description = "A script to build and deploy a Balius smart contract to the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/scripts/deploy/Cargo.toml
+++ b/scripts/deploy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-deploy"
-version = "0.2.1"
+version = "0.3.0"
 description = "A script to build and deploy a Balius-backed API to FireFly"
 license-file.workspace = true
 publish = false

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-generate-key"
-version = "0.2.1"
+version = "0.3.0"
 description = "A script to easily generate Cardano addresses"
 license-file.workspace = true
 publish = false

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -298,7 +298,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "firefly-balius"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "balius-sdk",
  "hex",

--- a/wasm/simple-tx/contract.json
+++ b/wasm/simple-tx/contract.json
@@ -30,6 +30,34 @@
         }
       ],
       "returns": []
+    },
+    {
+      "description": "Queries the current state of this contract",
+      "details": {},
+      "name": "query_current_state",
+      "params": [],
+      "returns": [
+        {
+          "type": "object",
+          "properties": {
+            "submittedTxs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "pendingTxs": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
     }
   ],
   "events": [


### PR DESCRIPTION
# Context

The FireFly API supports a "query" endpoint, which is allowed to synchronously read arbitrary data from a contract. This is easy to support and makes contracts much more flexible.

# Important Changes Introduced

Add a `/contracts/query` endpoint. This just directly calls a method on a Balius contract and returns the response. It will throw if the response is a partial transaction, which prevents it from making any on-chain changes.