### PR TITLE
fix(nix): corrected follows reference in devshell.inputs  

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For the firefly signer config, see [config.md](firefly-cardanosigner/config.md).
 
 ## Getting started
 
-To setup the components, you need a valid Blockfrost key, you can either [get it from the online service](https://blockfrost.io/) or [your can run your own cluster](https://github.com/blockfrost/blockfrost-backend-ryo).
+To setup the components, you need a valid Blockfrost key, you can either [get it from the online service](https://blockfrost.io/) or [you can run your own cluster](https://github.com/blockfrost/blockfrost-backend-ryo).
 
 ### Run it with Docker compose
 

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     devshell.url = "github:numtide/devshell";
-    devshell.inputs.nixpkgs.follows = "";
+    devshell.inputs.nixpkgs.follows = "nixpkgs";
 
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";


### PR DESCRIPTION
fix(nix): corrected follows reference in devshell.inputs  
devshell.inputs.nixpkgs.follows now correctly points to "nixpkgs".

fix(docs): fixed typo "your can run" → "you can run" in the "Getting started" section.
