### PR TITLE
feat: return and monitor TXs from the same method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-balius"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "balius-sdk",
  "hex",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-demo"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-deploy"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-deploy-contract"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-generate-key"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardanoconnect"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aide",
  "anyhow",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardanosigner"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aide",
  "anyhow",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-server"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aide",
  "anyhow",

--- a/firefly-balius/Cargo.toml
+++ b/firefly-balius/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-balius"
-version = "0.4.0"
+version = "0.4.1"
 description = "Helpers to write contracts for the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardanoconnect"
-version = "0.4.0"
+version = "0.4.1"
 description = "An implementation of the FireFly Connector API for Cardano"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanoconnect/src/operations/manager.rs
+++ b/firefly-cardanoconnect/src/operations/manager.rs
@@ -85,9 +85,9 @@ impl OperationsManager {
             }
         };
         if let Some(tx) = value {
-            let tx_id = self.submit_transaction(from, tx).await?;
+            let tx_id = self.submit_transaction(from, &tx.bytes).await?;
             op.tx_id = Some(tx_id.clone());
-            self.contracts.handle_submit(contract, method, &tx_id).await;
+            self.contracts.handle_submit(contract, &tx_id, tx).await?;
         }
 
         op.status = OperationStatus::Succeeded;
@@ -114,8 +114,8 @@ impl OperationsManager {
         Ok(())
     }
 
-    async fn submit_transaction(&self, address: &str, tx: Vec<u8>) -> ApiResult<String> {
-        let mut transaction: Tx = minicbor::decode(&tx)?;
+    async fn submit_transaction(&self, address: &str, tx: &[u8]) -> ApiResult<String> {
+        let mut transaction: Tx = minicbor::decode(tx)?;
         self.signer
             .sign(address.to_string(), &mut transaction)
             .await?;

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardanosigner"
-version = "0.4.0"
+version = "0.4.1"
 description = "A service managing keys and signing for the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/firefly-server/Cargo.toml
+++ b/firefly-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-server"
-version = "0.4.0"
+version = "0.4.1"
 description = "Internal library with shared code for services"
 license-file.workspace = true
 publish = false

--- a/scripts/demo/Cargo.toml
+++ b/scripts/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-demo"
-version = "0.4.0"
+version = "0.4.1"
 description = "A demo of the firefly-cardanoconnect API"
 license-file.workspace = true
 publish = false

--- a/scripts/deploy-contract/Cargo.toml
+++ b/scripts/deploy-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-deploy-contract"
-version = "0.4.0"
+version = "0.4.1"
 description = "A script to build and deploy a Balius smart contract to the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/scripts/deploy/Cargo.toml
+++ b/scripts/deploy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-deploy"
-version = "0.4.0"
+version = "0.4.1"
 description = "A script to build and deploy a Balius-backed API to FireFly"
 license-file.workspace = true
 publish = false

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-generate-key"
-version = "0.4.0"
+version = "0.4.1"
 description = "A script to easily generate Cardano addresses"
 license-file.workspace = true
 publish = false

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -300,7 +300,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "firefly-balius"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "balius-sdk",
  "hex",


### PR DESCRIPTION
# Context

We want to make it easy to build dApps, by removing as much blockchain boilerplate as possible from workers. This change lets developers write a single method which tells the framework to create a transaction, submit it on-chain, and fire events when it gets rolled back or finalized.

# Important Changes Introduced

Add a `NewMonitoredTx` return type which contract methods are allowed to return. When a method returns `NewMonitoredTx`, the runtime will submit that TX and automatically monitor it (emit lifecycle events for it).