### PR TITLE
Pallas v1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[net]
+git-fetch-with-cli = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,7 +2408,7 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
+source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
 dependencies = [
  "base58",
  "bech32 0.9.1",
@@ -2451,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
+source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
 dependencies = [
  "hex",
  "minicbor 0.26.0",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
+source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
 dependencies = [
  "cryptoxide",
  "hex",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "pallas-network"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
+source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
 dependencies = [
  "byteorder",
  "hex",
@@ -2559,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "pallas-primitives"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
+source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
 dependencies = [
  "hex",
  "pallas-codec 1.0.0-alpha.1",
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "pallas-traverse"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
+source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
 dependencies = [
  "hex",
  "itertools 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,8 +1187,8 @@ dependencies = [
  "clap",
  "hex",
  "minicbor 0.26.0",
- "pallas-crypto 1.0.0-alpha.1",
- "pallas-primitives 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.2",
+ "pallas-primitives 1.0.0-alpha.2",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -1214,12 +1214,12 @@ dependencies = [
  "minicbor 0.26.0",
  "num-rational",
  "num-traits",
- "pallas-addresses 1.0.0-alpha.1",
- "pallas-codec 1.0.0-alpha.1",
- "pallas-crypto 1.0.0-alpha.1",
- "pallas-network 1.0.0-alpha.1",
- "pallas-primitives 1.0.0-alpha.1",
- "pallas-traverse 1.0.0-alpha.1",
+ "pallas-addresses 1.0.0-alpha.2",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
+ "pallas-network 1.0.0-alpha.2",
+ "pallas-primitives 1.0.0-alpha.2",
+ "pallas-traverse 1.0.0-alpha.2",
  "rand 0.9.0",
  "rand_chacha 0.9.0",
  "refinery",
@@ -1247,9 +1247,9 @@ dependencies = [
  "firefly-server",
  "hex",
  "minicbor 0.26.0",
- "pallas-addresses 1.0.0-alpha.1",
- "pallas-crypto 1.0.0-alpha.1",
- "pallas-primitives 1.0.0-alpha.1",
+ "pallas-addresses 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
+ "pallas-primitives 1.0.0-alpha.2",
  "rand 0.9.0",
  "schemars",
  "serde",
@@ -2407,16 +2407,17 @@ dependencies = [
 
 [[package]]
 name = "pallas-addresses"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f0bf697964d0562ee36727834f3fb698bdcf71dc2fef8c2f15e4e8920c6b55"
 dependencies = [
  "base58",
  "bech32 0.9.1",
  "crc",
  "cryptoxide",
  "hex",
- "pallas-codec 1.0.0-alpha.1",
- "pallas-crypto 1.0.0-alpha.1",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
  "thiserror 1.0.69",
 ]
 
@@ -2450,8 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-codec"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51205265dc1f976a09e845abb4303e6704de54e377d3350ee30be70b26249f7f"
 dependencies = [
  "hex",
  "minicbor 0.26.0",
@@ -2494,12 +2496,13 @@ dependencies = [
 
 [[package]]
 name = "pallas-crypto"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d62094c2f70164cd878b4f3ae2f81f79aca79d7b3a2a5db2fa15d09002d5f7d"
 dependencies = [
  "cryptoxide",
  "hex",
- "pallas-codec 1.0.0-alpha.1",
+ "pallas-codec 1.0.0-alpha.2",
  "rand_core 0.6.4",
  "serde",
  "thiserror 1.0.69",
@@ -2525,14 +2528,15 @@ dependencies = [
 
 [[package]]
 name = "pallas-network"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "689a470fe83eb0bc02014681a55614d183c8e339cae3126fcbe8a40cdad23aaf"
 dependencies = [
  "byteorder",
  "hex",
  "itertools 0.13.0",
- "pallas-codec 1.0.0-alpha.1",
- "pallas-crypto 1.0.0-alpha.1",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
  "rand 0.8.5",
  "socket2",
  "thiserror 1.0.69",
@@ -2558,12 +2562,13 @@ dependencies = [
 
 [[package]]
 name = "pallas-primitives"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db6f5bff8e1163e33dd116814c7288866928219cb84c90803f41b2d3ec0edc1"
 dependencies = [
  "hex",
- "pallas-codec 1.0.0-alpha.1",
- "pallas-crypto 1.0.0-alpha.1",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
  "serde",
  "serde_json",
 ]
@@ -2587,15 +2592,16 @@ dependencies = [
 
 [[package]]
 name = "pallas-traverse"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
+version = "1.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9121e2b43a76b06331e5527c2948da2eef5731f84499e5a3d737a62c7d96f6a"
 dependencies = [
  "hex",
  "itertools 0.13.0",
- "pallas-addresses 1.0.0-alpha.1",
- "pallas-codec 1.0.0-alpha.1",
- "pallas-crypto 1.0.0-alpha.1",
- "pallas-primitives 1.0.0-alpha.1",
+ "pallas-addresses 1.0.0-alpha.2",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
+ "pallas-primitives 1.0.0-alpha.2",
  "paste",
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,7 +2408,7 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
+source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
 dependencies = [
  "base58",
  "bech32 0.9.1",
@@ -2451,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
+source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
 dependencies = [
  "hex",
  "minicbor 0.26.0",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
+source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
 dependencies = [
  "cryptoxide",
  "hex",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "pallas-network"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
+source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
 dependencies = [
  "byteorder",
  "hex",
@@ -2559,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "pallas-primitives"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
+source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
 dependencies = [
  "hex",
  "pallas-codec 1.0.0-alpha.0",
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "pallas-traverse"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
+source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
 dependencies = [
  "hex",
  "itertools 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,6 @@ dependencies = [
  "pallas-addresses 1.0.0-alpha.0",
  "pallas-crypto 1.0.0-alpha.0",
  "pallas-primitives 1.0.0-alpha.0",
- "pallas-wallet 1.0.0-alpha.0",
  "rand 0.9.0",
  "schemars",
  "serde",
@@ -2614,7 +2613,7 @@ dependencies = [
  "pallas-crypto 0.32.0",
  "pallas-primitives 0.32.0",
  "pallas-traverse 0.32.0",
- "pallas-wallet 0.32.0",
+ "pallas-wallet",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2646,20 +2645,6 @@ dependencies = [
  "cryptoxide",
  "ed25519-bip32",
  "pallas-crypto 0.32.0",
- "rand 0.8.5",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "pallas-wallet"
-version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
-dependencies = [
- "bech32 0.9.1",
- "bip39",
- "cryptoxide",
- "ed25519-bip32",
- "pallas-crypto 1.0.0-alpha.0",
  "rand 0.8.5",
  "thiserror 1.0.69",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,8 +2409,7 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "1.0.0-alpha.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39c3f7a9a5f23e1dce67d8bf5d5f86320b470132304d7c63a5c380ebbe88daf"
+source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
 dependencies = [
  "base58",
  "bech32 0.9.1",
@@ -2453,8 +2452,7 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "1.0.0-alpha.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b0ecbf95c2dfdfec43e43f2b23f7742bf44a9088141bcc21b64322a6c9fb1a"
+source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
 dependencies = [
  "hex",
  "minicbor 0.26.0",
@@ -2498,8 +2496,7 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "1.0.0-alpha.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10ea22315c02348d6a96b56a7dbec5dde1e13e19e901e8de45fd41829e38ecae"
+source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
 dependencies = [
  "cryptoxide",
  "hex",
@@ -2530,8 +2527,7 @@ dependencies = [
 [[package]]
 name = "pallas-network"
 version = "1.0.0-alpha.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744bd14d67618f773a2d7e5b1a7287544acd1bbda9a8d467e6bcc6f8ca7361f"
+source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
 dependencies = [
  "byteorder",
  "hex",
@@ -2564,8 +2560,7 @@ dependencies = [
 [[package]]
 name = "pallas-primitives"
 version = "1.0.0-alpha.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab585ee4fd286dcfdaac590c032db17df7e9b1d986a2546f86baca02897a1d6f"
+source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
 dependencies = [
  "hex",
  "pallas-codec 1.0.0-alpha.0",
@@ -2594,8 +2589,7 @@ dependencies = [
 [[package]]
 name = "pallas-traverse"
 version = "1.0.0-alpha.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "811554359d7bee8f683c8cbc4ee9aeb262a956ea232222f8aeff8d4c5c2002ed"
+source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
 dependencies = [
  "hex",
  "itertools 0.13.0",
@@ -2659,8 +2653,7 @@ dependencies = [
 [[package]]
 name = "pallas-wallet"
 version = "1.0.0-alpha.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46b48ae6ef1fd4800443a805a0747a64c7e53c2d94925a58598a467416359f4"
+source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
 dependencies = [
  "bech32 0.9.1",
  "bip39",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,7 +2408,7 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
+source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
 dependencies = [
  "base58",
  "bech32 0.9.1",
@@ -2451,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
+source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
 dependencies = [
  "hex",
  "minicbor 0.26.0",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
+source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
 dependencies = [
  "cryptoxide",
  "hex",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "pallas-network"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
+source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
 dependencies = [
  "byteorder",
  "hex",
@@ -2559,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "pallas-primitives"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
+source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
 dependencies = [
  "hex",
  "pallas-codec 1.0.0-alpha.1",
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "pallas-traverse"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
+source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
 dependencies = [
  "hex",
  "itertools 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,8 +1187,8 @@ dependencies = [
  "clap",
  "hex",
  "minicbor 0.26.0",
- "pallas-crypto 1.0.0-alpha.0",
- "pallas-primitives 1.0.0-alpha.0",
+ "pallas-crypto 1.0.0-alpha.1",
+ "pallas-primitives 1.0.0-alpha.1",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -1214,12 +1214,12 @@ dependencies = [
  "minicbor 0.26.0",
  "num-rational",
  "num-traits",
- "pallas-addresses 1.0.0-alpha.0",
- "pallas-codec 1.0.0-alpha.0",
- "pallas-crypto 1.0.0-alpha.0",
- "pallas-network 1.0.0-alpha.0",
- "pallas-primitives 1.0.0-alpha.0",
- "pallas-traverse 1.0.0-alpha.0",
+ "pallas-addresses 1.0.0-alpha.1",
+ "pallas-codec 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.1",
+ "pallas-network 1.0.0-alpha.1",
+ "pallas-primitives 1.0.0-alpha.1",
+ "pallas-traverse 1.0.0-alpha.1",
  "rand 0.9.0",
  "rand_chacha 0.9.0",
  "refinery",
@@ -1247,9 +1247,9 @@ dependencies = [
  "firefly-server",
  "hex",
  "minicbor 0.26.0",
- "pallas-addresses 1.0.0-alpha.0",
- "pallas-crypto 1.0.0-alpha.0",
- "pallas-primitives 1.0.0-alpha.0",
+ "pallas-addresses 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.1",
+ "pallas-primitives 1.0.0-alpha.1",
  "rand 0.9.0",
  "schemars",
  "serde",
@@ -2407,16 +2407,16 @@ dependencies = [
 
 [[package]]
 name = "pallas-addresses"
-version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
+version = "1.0.0-alpha.1"
+source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
 dependencies = [
  "base58",
  "bech32 0.9.1",
  "crc",
  "cryptoxide",
  "hex",
- "pallas-codec 1.0.0-alpha.0",
- "pallas-crypto 1.0.0-alpha.0",
+ "pallas-codec 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.1",
  "thiserror 1.0.69",
 ]
 
@@ -2450,8 +2450,8 @@ dependencies = [
 
 [[package]]
 name = "pallas-codec"
-version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
+version = "1.0.0-alpha.1"
+source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
 dependencies = [
  "hex",
  "minicbor 0.26.0",
@@ -2494,12 +2494,12 @@ dependencies = [
 
 [[package]]
 name = "pallas-crypto"
-version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
+version = "1.0.0-alpha.1"
+source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
 dependencies = [
  "cryptoxide",
  "hex",
- "pallas-codec 1.0.0-alpha.0",
+ "pallas-codec 1.0.0-alpha.1",
  "rand_core 0.6.4",
  "serde",
  "thiserror 1.0.69",
@@ -2525,14 +2525,14 @@ dependencies = [
 
 [[package]]
 name = "pallas-network"
-version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
+version = "1.0.0-alpha.1"
+source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
 dependencies = [
  "byteorder",
  "hex",
  "itertools 0.13.0",
- "pallas-codec 1.0.0-alpha.0",
- "pallas-crypto 1.0.0-alpha.0",
+ "pallas-codec 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.1",
  "rand 0.8.5",
  "socket2",
  "thiserror 1.0.69",
@@ -2558,12 +2558,12 @@ dependencies = [
 
 [[package]]
 name = "pallas-primitives"
-version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
+version = "1.0.0-alpha.1"
+source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
 dependencies = [
  "hex",
- "pallas-codec 1.0.0-alpha.0",
- "pallas-crypto 1.0.0-alpha.0",
+ "pallas-codec 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.1",
  "serde",
  "serde_json",
 ]
@@ -2587,15 +2587,15 @@ dependencies = [
 
 [[package]]
 name = "pallas-traverse"
-version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
+version = "1.0.0-alpha.1"
+source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
 dependencies = [
  "hex",
  "itertools 0.13.0",
- "pallas-addresses 1.0.0-alpha.0",
- "pallas-codec 1.0.0-alpha.0",
- "pallas-crypto 1.0.0-alpha.0",
- "pallas-primitives 1.0.0-alpha.0",
+ "pallas-addresses 1.0.0-alpha.1",
+ "pallas-codec 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.1",
+ "pallas-primitives 1.0.0-alpha.1",
  "paste",
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-balius"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "balius-sdk",
  "hex",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-demo"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-deploy"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-deploy-contract"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-generate-key"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardanoconnect"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aide",
  "anyhow",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardanosigner"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aide",
  "anyhow",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-server"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aide",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,11 +406,11 @@ checksum = "258e9d00f2a7b551cf930812a865a0d3e1e87b508c96a121296c7d2774b0ba88"
 dependencies = [
  "balius-macros",
  "hex",
- "pallas-addresses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-codec 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-crypto 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-primitives 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-traverse 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallas-addresses 0.32.0",
+ "pallas-codec 0.32.0",
+ "pallas-crypto 0.32.0",
+ "pallas-primitives 0.32.0",
+ "pallas-traverse 0.32.0",
  "prost",
  "serde",
  "serde_json",
@@ -1187,8 +1187,8 @@ dependencies = [
  "clap",
  "hex",
  "minicbor 0.26.0",
- "pallas-crypto 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-primitives 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
+ "pallas-crypto 1.0.0-alpha.0",
+ "pallas-primitives 1.0.0-alpha.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -1214,12 +1214,12 @@ dependencies = [
  "minicbor 0.26.0",
  "num-rational",
  "num-traits",
- "pallas-addresses 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-codec 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-crypto 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-network 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-primitives 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-traverse 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
+ "pallas-addresses 1.0.0-alpha.0",
+ "pallas-codec 1.0.0-alpha.0",
+ "pallas-crypto 1.0.0-alpha.0",
+ "pallas-network 1.0.0-alpha.0",
+ "pallas-primitives 1.0.0-alpha.0",
+ "pallas-traverse 1.0.0-alpha.0",
  "rand 0.9.0",
  "rand_chacha 0.9.0",
  "refinery",
@@ -1247,10 +1247,10 @@ dependencies = [
  "firefly-server",
  "hex",
  "minicbor 0.26.0",
- "pallas-addresses 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-crypto 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-primitives 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-wallet 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
+ "pallas-addresses 1.0.0-alpha.0",
+ "pallas-crypto 1.0.0-alpha.0",
+ "pallas-primitives 1.0.0-alpha.0",
+ "pallas-wallet 1.0.0-alpha.0",
  "rand 0.9.0",
  "schemars",
  "serde",
@@ -2379,13 +2379,13 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6092359c94e86cfc1047b4b5da8284d6d2ee22e4bf0eaa6d9ee8158fb8f1c5b"
 dependencies = [
- "pallas-addresses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-codec 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallas-addresses 0.32.0",
+ "pallas-codec 0.32.0",
  "pallas-configs",
- "pallas-crypto 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-network 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-primitives 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-traverse 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallas-crypto 0.32.0",
+ "pallas-network 0.32.0",
+ "pallas-primitives 0.32.0",
+ "pallas-traverse 0.32.0",
  "pallas-txbuilder",
  "pallas-utxorpc",
 ]
@@ -2401,23 +2401,24 @@ dependencies = [
  "crc",
  "cryptoxide",
  "hex",
- "pallas-codec 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-crypto 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallas-codec 0.32.0",
+ "pallas-crypto 0.32.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "pallas-addresses"
-version = "0.32.0"
-source = "git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e#2ddb5b066bbde9d2ed55014b286f47ad370b828e"
+version = "1.0.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f39c3f7a9a5f23e1dce67d8bf5d5f86320b470132304d7c63a5c380ebbe88daf"
 dependencies = [
  "base58",
  "bech32 0.9.1",
  "crc",
  "cryptoxide",
  "hex",
- "pallas-codec 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-crypto 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
+ "pallas-codec 1.0.0-alpha.0",
+ "pallas-crypto 1.0.0-alpha.0",
  "thiserror 1.0.69",
 ]
 
@@ -2429,11 +2430,11 @@ checksum = "15e103c84957d01753f2103c9d2e8f845638309af54d899c1c857e0b0d45cbcf"
 dependencies = [
  "chrono",
  "hex",
- "pallas-addresses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-codec 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-crypto 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-primitives 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-traverse 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallas-addresses 0.32.0",
+ "pallas-codec 0.32.0",
+ "pallas-crypto 0.32.0",
+ "pallas-primitives 0.32.0",
+ "pallas-traverse 0.32.0",
  "rand 0.8.5",
 ]
 
@@ -2451,8 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-codec"
-version = "0.32.0"
-source = "git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e#2ddb5b066bbde9d2ed55014b286f47ad370b828e"
+version = "1.0.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b0ecbf95c2dfdfec43e43f2b23f7742bf44a9088141bcc21b64322a6c9fb1a"
 dependencies = [
  "hex",
  "minicbor 0.26.0",
@@ -2469,10 +2471,10 @@ dependencies = [
  "base64 0.22.1",
  "hex",
  "num-rational",
- "pallas-addresses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-codec 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-crypto 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-primitives 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallas-addresses 0.32.0",
+ "pallas-codec 0.32.0",
+ "pallas-crypto 0.32.0",
+ "pallas-primitives 0.32.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -2486,7 +2488,7 @@ checksum = "37c1d642326ce402eb9191aeacc3dd0bf2b499848e97a56396c978a6eb9dd31a"
 dependencies = [
  "cryptoxide",
  "hex",
- "pallas-codec 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallas-codec 0.32.0",
  "rand_core 0.6.4",
  "serde",
  "thiserror 1.0.69",
@@ -2495,16 +2497,16 @@ dependencies = [
 
 [[package]]
 name = "pallas-crypto"
-version = "0.32.0"
-source = "git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e#2ddb5b066bbde9d2ed55014b286f47ad370b828e"
+version = "1.0.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ea22315c02348d6a96b56a7dbec5dde1e13e19e901e8de45fd41829e38ecae"
 dependencies = [
  "cryptoxide",
  "hex",
- "pallas-codec 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
+ "pallas-codec 1.0.0-alpha.0",
  "rand_core 0.6.4",
  "serde",
  "thiserror 1.0.69",
- "zeroize",
 ]
 
 [[package]]
@@ -2516,8 +2518,8 @@ dependencies = [
  "byteorder",
  "hex",
  "itertools 0.13.0",
- "pallas-codec 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-crypto 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallas-codec 0.32.0",
+ "pallas-crypto 0.32.0",
  "rand 0.8.5",
  "socket2",
  "thiserror 1.0.69",
@@ -2527,14 +2529,15 @@ dependencies = [
 
 [[package]]
 name = "pallas-network"
-version = "0.32.0"
-source = "git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e#2ddb5b066bbde9d2ed55014b286f47ad370b828e"
+version = "1.0.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744bd14d67618f773a2d7e5b1a7287544acd1bbda9a8d467e6bcc6f8ca7361f"
 dependencies = [
  "byteorder",
  "hex",
  "itertools 0.13.0",
- "pallas-codec 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-crypto 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
+ "pallas-codec 1.0.0-alpha.0",
+ "pallas-crypto 1.0.0-alpha.0",
  "rand 0.8.5",
  "socket2",
  "thiserror 1.0.69",
@@ -2552,23 +2555,21 @@ dependencies = [
  "bech32 0.9.1",
  "hex",
  "log",
- "pallas-codec 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-crypto 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallas-codec 0.32.0",
+ "pallas-crypto 0.32.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "pallas-primitives"
-version = "0.32.0"
-source = "git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e#2ddb5b066bbde9d2ed55014b286f47ad370b828e"
+version = "1.0.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab585ee4fd286dcfdaac590c032db17df7e9b1d986a2546f86baca02897a1d6f"
 dependencies = [
- "base58",
- "bech32 0.9.1",
  "hex",
- "log",
- "pallas-codec 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-crypto 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
+ "pallas-codec 1.0.0-alpha.0",
+ "pallas-crypto 1.0.0-alpha.0",
  "serde",
  "serde_json",
 ]
@@ -2581,10 +2582,10 @@ checksum = "02d2572d316883fe866ae648bc3c5357e70cbbe8de5d78b1246f6109520fa52f"
 dependencies = [
  "hex",
  "itertools 0.13.0",
- "pallas-addresses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-codec 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-crypto 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-primitives 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallas-addresses 0.32.0",
+ "pallas-codec 0.32.0",
+ "pallas-crypto 0.32.0",
+ "pallas-primitives 0.32.0",
  "paste",
  "serde",
  "thiserror 1.0.69",
@@ -2592,15 +2593,16 @@ dependencies = [
 
 [[package]]
 name = "pallas-traverse"
-version = "0.32.0"
-source = "git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e#2ddb5b066bbde9d2ed55014b286f47ad370b828e"
+version = "1.0.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811554359d7bee8f683c8cbc4ee9aeb262a956ea232222f8aeff8d4c5c2002ed"
 dependencies = [
  "hex",
  "itertools 0.13.0",
- "pallas-addresses 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-codec 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-crypto 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
- "pallas-primitives 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
+ "pallas-addresses 1.0.0-alpha.0",
+ "pallas-codec 1.0.0-alpha.0",
+ "pallas-crypto 1.0.0-alpha.0",
+ "pallas-primitives 1.0.0-alpha.0",
  "paste",
  "serde",
  "thiserror 1.0.69",
@@ -2613,12 +2615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b126cd2f387af2478f9b0f6b422c613f74024350600cf5bd7c31e2c85c3c7062"
 dependencies = [
  "hex",
- "pallas-addresses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-codec 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-crypto 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-primitives 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-traverse 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-wallet 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallas-addresses 0.32.0",
+ "pallas-codec 0.32.0",
+ "pallas-crypto 0.32.0",
+ "pallas-primitives 0.32.0",
+ "pallas-traverse 0.32.0",
+ "pallas-wallet 0.32.0",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2631,10 +2633,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "609f39f3f9b8ff0e8593bfc3e6e3c53a14dd3ed41e1dfac24a41541fc7cab620"
 dependencies = [
  "pallas-applying",
- "pallas-codec 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-crypto 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-primitives 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallas-traverse 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallas-codec 0.32.0",
+ "pallas-crypto 0.32.0",
+ "pallas-primitives 0.32.0",
+ "pallas-traverse 0.32.0",
  "prost-types",
  "utxorpc-spec 0.15.0",
 ]
@@ -2649,21 +2651,22 @@ dependencies = [
  "bip39",
  "cryptoxide",
  "ed25519-bip32",
- "pallas-crypto 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallas-crypto 0.32.0",
  "rand 0.8.5",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "pallas-wallet"
-version = "0.32.0"
-source = "git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e#2ddb5b066bbde9d2ed55014b286f47ad370b828e"
+version = "1.0.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46b48ae6ef1fd4800443a805a0747a64c7e53c2d94925a58598a467416359f4"
 dependencies = [
  "bech32 0.9.1",
  "bip39",
  "cryptoxide",
  "ed25519-bip32",
- "pallas-crypto 0.32.0 (git+https://github.com/txpipe/pallas.git?rev=2ddb5b066bbde9d2ed55014b286f47ad370b828e)",
+ "pallas-crypto 1.0.0-alpha.0",
  "rand 0.8.5",
  "thiserror 1.0.69",
 ]

--- a/firefly-balius/Cargo.toml
+++ b/firefly-balius/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-balius"
-version = "0.4.1"
+version = "0.4.2"
 description = "Helpers to write contracts for the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -19,12 +19,12 @@ clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
 dashmap = "6"
 futures = "0.3"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
-pallas-codec = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
-pallas-network = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
-pallas-traverse = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
+pallas-codec = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
+pallas-network = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
+pallas-traverse = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -19,12 +19,12 @@ clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
 dashmap = "6"
 futures = "0.3"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
-pallas-codec = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
-pallas-network = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
-pallas-traverse = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
+pallas-codec = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
+pallas-network = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
+pallas-traverse = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -19,12 +19,12 @@ clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
 dashmap = "6"
 futures = "0.3"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
-pallas-codec = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
-pallas-network = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
-pallas-traverse = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
+pallas-codec = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
+pallas-network = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
+pallas-traverse = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardanoconnect"
-version = "0.4.1"
+version = "0.4.2"
 description = "An implementation of the FireFly Connector API for Cardano"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -19,12 +19,12 @@ clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
 dashmap = "6"
 futures = "0.3"
-pallas-addresses = "1.0.0-alpha.0"
-pallas-codec = "1.0.0-alpha.0"
-pallas-crypto = "1.0.0-alpha.0"
-pallas-primitives = "1.0.0-alpha.0"
-pallas-network = "1.0.0-alpha.0"
-pallas-traverse = "1.0.0-alpha.0"
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
+pallas-codec = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
+pallas-network = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
+pallas-traverse = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -19,12 +19,12 @@ clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
 dashmap = "6"
 futures = "0.3"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
-pallas-codec = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
-pallas-network = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
-pallas-traverse = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
+pallas-codec = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
+pallas-network = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
+pallas-traverse = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -19,12 +19,12 @@ clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
 dashmap = "6"
 futures = "0.3"
-pallas-addresses = { git = "https://github.com/txpipe/pallas.git", rev = "2ddb5b066bbde9d2ed55014b286f47ad370b828e" }
-pallas-codec = { git = "https://github.com/txpipe/pallas.git", rev = "2ddb5b066bbde9d2ed55014b286f47ad370b828e" }
-pallas-crypto = { git = "https://github.com/txpipe/pallas.git", rev = "2ddb5b066bbde9d2ed55014b286f47ad370b828e" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas.git", rev = "2ddb5b066bbde9d2ed55014b286f47ad370b828e" }
-pallas-network = { git = "https://github.com/txpipe/pallas.git", rev = "2ddb5b066bbde9d2ed55014b286f47ad370b828e" }
-pallas-traverse = { git = "https://github.com/txpipe/pallas.git", rev = "2ddb5b066bbde9d2ed55014b286f47ad370b828e" }
+pallas-addresses = "1.0.0-alpha.0"
+pallas-codec = "1.0.0-alpha.0"
+pallas-crypto = "1.0.0-alpha.0"
+pallas-primitives = "1.0.0-alpha.0"
+pallas-network = "1.0.0-alpha.0"
+pallas-traverse = "1.0.0-alpha.0"
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -19,12 +19,12 @@ clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
 dashmap = "6"
 futures = "0.3"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
-pallas-codec = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
-pallas-network = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
-pallas-traverse = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
+pallas-addresses = "1.0.0-alpha.2"
+pallas-codec = "1.0.0-alpha.2"
+pallas-crypto = "1.0.0-alpha.2"
+pallas-primitives = "1.0.0-alpha.2"
+pallas-network = "1.0.0-alpha.2"
+pallas-traverse = "1.0.0-alpha.2"
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"

--- a/firefly-cardanoconnect/config.md
+++ b/firefly-cardanoconnect/config.md
@@ -21,6 +21,13 @@
 |networkMagic|An optional magic number|`int`|depends on `network`
 |genesisHash|The hash of the genesis block|`string`|depends on `network`
 
+## contracts
+|Key|Description|Type|Default Value|
+|---|-----------|----|-------------|
+|componentsPath|Path on-disk to store the wasm components which define contracts|`string`||
+|storesPath|Path on-disk to store persistent data for contracts|`string`||
+|cacheSize|The amount of memory (in bytes) used to cache data|`number`|0|
+
 ## http
 
 |Key|Description|Type|Default Value|

--- a/firefly-cardanoconnect/src/blockchain.rs
+++ b/firefly-cardanoconnect/src/blockchain.rs
@@ -137,7 +137,7 @@ impl BlockchainClient {
         }
     }
 
-    pub async fn submit(&self, transaction: Tx) -> Result<String> {
+    pub async fn submit(&self, transaction: Tx<'_>) -> Result<String> {
         match &self.client {
             ClientImpl::Blockfrost(bf) => bf.submit(transaction).await,
             ClientImpl::Mock(_) => bail!("mock transaction submission not implemented"),

--- a/firefly-cardanoconnect/src/blockchain/blockfrost.rs
+++ b/firefly-cardanoconnect/src/blockchain/blockfrost.rs
@@ -21,7 +21,7 @@ impl Blockfrost {
         }
     }
 
-    pub async fn submit(&self, transaction: Tx) -> Result<String> {
+    pub async fn submit(&self, transaction: Tx<'_>) -> Result<String> {
         let transaction_data = {
             let mut bytes = vec![];
             minicbor::encode(transaction, &mut bytes).expect("infallible");

--- a/firefly-cardanoconnect/src/blockchain/n2c.rs
+++ b/firefly-cardanoconnect/src/blockchain/n2c.rs
@@ -52,7 +52,7 @@ impl NodeToClient {
         }
     }
 
-    pub async fn submit(&mut self, transaction: Tx, era: u16) -> Result<String> {
+    pub async fn submit(&mut self, transaction: Tx<'_>, era: u16) -> Result<String> {
         let txid = {
             let txid_bytes = Hasher::<256>::hash_cbor(&transaction.transaction_body);
             hex::encode(txid_bytes)

--- a/firefly-cardanoconnect/src/blockchain/n2c/ledger.rs
+++ b/firefly-cardanoconnect/src/blockchain/n2c/ledger.rs
@@ -279,7 +279,6 @@ fn encode_transaction_output(output: &TransactionOutput) -> Result<Vec<u8>> {
     };
     let mut buffer = vec![];
     minicbor::encode(&txo, &mut buffer).expect("infallible");
-    minicbor::encode(output, &mut buffer).expect("infallible");
     Ok(buffer)
 }
 

--- a/firefly-cardanoconnect/src/blockchain/n2c/ledger.rs
+++ b/firefly-cardanoconnect/src/blockchain/n2c/ledger.rs
@@ -19,7 +19,7 @@ use pallas_network::{
 };
 use pallas_primitives::{KeepRaw, PositiveCoin, alonzo, conway};
 use utxorpc_spec::utxorpc::v1alpha::cardano::{
-    CostModel, CostModels, ExPrices, ExUnits, PParams, VotingThresholds,
+    CostModel, CostModels, ExPrices, ExUnits, PParams, ProtocolVersion, VotingThresholds,
 };
 
 use crate::{blockchain::BaliusLedger, utils::LazyInit};
@@ -164,15 +164,12 @@ impl BaliusLedger for NodeToClientLedger {
             if let Some(c) = param.min_pool_cost {
                 result.min_pool_cost = c.into();
             }
-            // TODO: uncomment
-            /*
             if let Some((major, minor)) = param.protocol_version {
                 result.protocol_version = Some(ProtocolVersion {
                     major: major as u32,
                     minor: minor as u32,
                 });
             }
-             */
             if let Some(s) = param.max_value_size {
                 result.max_value_size = s;
             }

--- a/firefly-cardanoconnect/src/blockchain/n2c/ledger.rs
+++ b/firefly-cardanoconnect/src/blockchain/n2c/ledger.rs
@@ -1,20 +1,18 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use balius_runtime::ledgers::{TxoRef, Utxo, UtxoPage};
-use pallas_codec::utils::{CborWrap, TagWrap};
 use pallas_network::{
     facades::NodeClient,
     miniprotocols::localstate::{
         self,
         queries_v16::{
-            RationalNumber, TransactionInput, TransactionOutput, TxIns, Value, get_current_pparams,
+            RationalNumber, TransactionInput, TransactionOutput, TxIns, get_current_pparams,
             get_utxo_by_address, get_utxo_by_txin,
         },
     },
 };
-use pallas_primitives::{Bytes, NonEmptyKeyValuePairs, PositiveCoin, alonzo, conway};
 use utxorpc_spec::utxorpc::v1alpha::cardano::{
-    CostModel, CostModels, ExPrices, ExUnits, PParams, ProtocolVersion, VotingThresholds,
+    CostModel, CostModels, ExPrices, ExUnits, PParams, VotingThresholds,
 };
 
 use crate::{blockchain::BaliusLedger, utils::LazyInit};
@@ -121,19 +119,19 @@ impl BaliusLedger for NodeToClientLedger {
                 result.coins_per_utxo_byte = ada.into();
             }
             if let Some(size) = param.max_transaction_size {
-                result.max_tx_size = size as u64;
+                result.max_tx_size = size;
             }
             if let Some(a) = param.minfee_a {
-                result.min_fee_coefficient = a as u64;
+                result.min_fee_coefficient = a;
             }
             if let Some(b) = param.minfee_b {
-                result.min_fee_constant = b as u64;
+                result.min_fee_constant = b;
             }
             if let Some(size) = param.max_block_body_size {
-                result.max_block_body_size = size as u64;
+                result.max_block_body_size = size;
             }
             if let Some(size) = param.max_block_header_size {
-                result.max_block_header_size = size as u64;
+                result.max_block_header_size = size;
             }
             if let Some(deposit) = param.key_deposit {
                 result.stake_key_deposit = deposit.into();
@@ -145,7 +143,7 @@ impl BaliusLedger for NodeToClientLedger {
                 result.pool_retirement_epoch_bound = bound;
             }
             if let Some(pools) = param.desired_number_of_stake_pools {
-                result.desired_number_of_pools = pools as u64;
+                result.desired_number_of_pools = pools;
             }
             if let Some(i) = param.pool_pledge_influence {
                 result.pool_influence = Some(map_rational(i));
@@ -159,20 +157,23 @@ impl BaliusLedger for NodeToClientLedger {
             if let Some(c) = param.min_pool_cost {
                 result.min_pool_cost = c.into();
             }
+            // TODO: uncomment
+            /*
             if let Some((major, minor)) = param.protocol_version {
                 result.protocol_version = Some(ProtocolVersion {
                     major: major as u32,
                     minor: minor as u32,
                 });
             }
+             */
             if let Some(s) = param.max_value_size {
-                result.max_value_size = s as u64;
+                result.max_value_size = s;
             }
             if let Some(p) = param.collateral_percentage {
-                result.collateral_percentage = p as u64;
+                result.collateral_percentage = p;
             }
             if let Some(i) = param.max_collateral_inputs {
-                result.max_collateral_inputs = i as u64;
+                result.max_collateral_inputs = i;
             }
             if let Some(models) = param.cost_models_for_script_languages {
                 result.cost_models = Some(CostModels {
@@ -190,16 +191,16 @@ impl BaliusLedger for NodeToClientLedger {
             if let Some(ex) = param.max_tx_ex_units {
                 result.max_execution_units_per_transaction = Some(ExUnits {
                     steps: ex.steps,
-                    memory: ex.mem as u64,
+                    memory: ex.mem,
                 });
             }
             if let Some(ex) = param.max_block_ex_units {
                 result.max_execution_units_per_block = Some(ExUnits {
                     steps: ex.steps,
-                    memory: ex.mem as u64,
+                    memory: ex.mem,
                 });
             }
-            if let Some(c) = param.min_fee_ref_script_cost_per_byte {
+            if let Some(c) = param.minfee_refscript_cost_per_byte {
                 result.min_fee_script_ref_cost_per_byte = Some(map_rational(c));
             }
             if let Some(t) = param.pool_voting_thresholds {
@@ -229,22 +230,22 @@ impl BaliusLedger for NodeToClientLedger {
                     ],
                 });
             }
-            if let Some(s) = param.committee_min_size {
+            if let Some(s) = param.min_committee_size {
                 result.min_committee_size = s as u32;
             }
-            if let Some(l) = param.committee_max_term_length {
+            if let Some(l) = param.committee_term_limit {
                 result.committee_term_limit = l;
             }
-            if let Some(g) = param.gov_action_lifetime {
+            if let Some(g) = param.governance_action_validity_period {
                 result.governance_action_validity_period = g;
             }
-            if let Some(g) = param.gov_action_deposit {
+            if let Some(g) = param.governance_action_deposit {
                 result.governance_action_deposit = g.into();
             }
             if let Some(d) = param.drep_deposit {
                 result.drep_deposit = d.into();
             }
-            if let Some(d) = param.drep_activity {
+            if let Some(d) = param.drep_inactivity_period {
                 result.drep_inactivity_period = d;
             }
         }
@@ -253,87 +254,9 @@ impl BaliusLedger for NodeToClientLedger {
 }
 
 fn encode_transaction_output(output: &TransactionOutput) -> Result<Vec<u8>> {
-    let txo = match output {
-        TransactionOutput::Legacy(o) => {
-            conway::TransactionOutput::Legacy(conway::LegacyTransactionOutput {
-                address: o.address.clone(),
-                amount: map_alonzo_value(&o.amount),
-                datum_hash: o.datum_hash,
-            })
-        }
-        TransactionOutput::Current(o) => {
-            conway::TransactionOutput::PostAlonzo(conway::PostAlonzoTransactionOutput {
-                address: o.address.clone(),
-                value: map_post_alonzo_value(&o.amount),
-                datum_option: o.inline_datum.as_ref().map(map_datum).transpose()?,
-                script_ref: o.script_ref.as_ref().map(map_script_ref).transpose()?,
-            })
-        }
-    };
     let mut buffer = vec![];
-    minicbor::encode(&txo, &mut buffer).expect("infallible");
+    minicbor::encode(output, &mut buffer).expect("infallible");
     Ok(buffer)
-}
-
-fn map_alonzo_value(v: &Value) -> alonzo::Value {
-    match v {
-        Value::Coin(coin) => alonzo::Value::Coin(coin.into()),
-        Value::Multiasset(coin, assets) => {
-            let coin = coin.into();
-            let assets = assets
-                .clone()
-                .to_vec()
-                .into_iter()
-                .map(|(policy_id, assets)| {
-                    let assets = assets
-                        .to_vec()
-                        .into_iter()
-                        .map(|(asset_name, value)| (asset_name, value.into()))
-                        .collect();
-                    (policy_id, assets)
-                })
-                .collect();
-            alonzo::Value::Multiasset(coin, assets)
-        }
-    }
-}
-
-fn map_post_alonzo_value(v: &Value) -> conway::Value {
-    match v {
-        Value::Coin(coin) => conway::Value::Coin(coin.into()),
-        Value::Multiasset(coin, assets) => {
-            let coin = coin.into();
-            let assets = assets
-                .clone()
-                .to_vec()
-                .into_iter()
-                .filter_map(|(policy_id, assets)| {
-                    let assets = assets
-                        .to_vec()
-                        .into_iter()
-                        .filter_map(|(asset_name, value)| {
-                            let coin = PositiveCoin::try_from(u64::from(value)).ok()?;
-                            Some((asset_name, coin))
-                        })
-                        .collect();
-                    Some((policy_id, NonEmptyKeyValuePairs::from_vec(assets)?))
-                })
-                .collect();
-            if let Some(assets) = NonEmptyKeyValuePairs::from_vec(assets) {
-                conway::Value::Multiasset(coin, assets)
-            } else {
-                conway::Value::Coin(coin)
-            }
-        }
-    }
-}
-
-fn map_datum(d: &(u16, TagWrap<Bytes, 24>)) -> Result<conway::DatumOption> {
-    Ok(minicbor::decode(&d.1)?)
-}
-
-fn map_script_ref(r: &TagWrap<Bytes, 24>) -> Result<CborWrap<conway::ScriptRef>> {
-    Ok(CborWrap(minicbor::decode(&r.0)?))
 }
 
 fn map_rational(r: RationalNumber) -> utxorpc_spec::utxorpc::v1alpha::cardano::RationalNumber {

--- a/firefly-cardanoconnect/src/routes/transaction.rs
+++ b/firefly-cardanoconnect/src/routes/transaction.rs
@@ -27,7 +27,8 @@ pub async fn submit_transaction(
     }): State<AppState>,
     Json(req): Json<SubmitTransactionRequest>,
 ) -> ApiResult<Json<SubmitTransactionResponse>> {
-    let mut transaction: Tx = minicbor::decode(&hex::decode(&req.transaction)?)?;
+    let transaction_bytes = hex::decode(&req.transaction)?;
+    let mut transaction: Tx = minicbor::decode(&transaction_bytes)?;
     signer
         .sign(req.address, &mut transaction)
         .await

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -19,7 +19,6 @@ minicbor = "0.26"
 pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
 pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
 pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
-pallas-wallet = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
 rand = "0.9"
 schemars = "0.8"
 serde = "1"

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -16,9 +16,9 @@ clap = { version = "4", features = ["derive"] }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
 rand = "0.9"
 schemars = "0.8"
 serde = "1"

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -16,10 +16,10 @@ clap = { version = "4", features = ["derive"] }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"
-pallas-addresses = { git = "https://github.com/txpipe/pallas.git", rev = "2ddb5b066bbde9d2ed55014b286f47ad370b828e" }
-pallas-crypto = { git = "https://github.com/txpipe/pallas.git", rev = "2ddb5b066bbde9d2ed55014b286f47ad370b828e" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas.git", rev = "2ddb5b066bbde9d2ed55014b286f47ad370b828e" }
-pallas-wallet = { git = "https://github.com/txpipe/pallas.git", rev = "2ddb5b066bbde9d2ed55014b286f47ad370b828e" }
+pallas-addresses = "1.0.0-alpha.0"
+pallas-crypto = "1.0.0-alpha.0"
+pallas-primitives = "1.0.0-alpha.0"
+pallas-wallet = "1.0.0-alpha.0"
 rand = "0.9"
 schemars = "0.8"
 serde = "1"

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -16,9 +16,9 @@ clap = { version = "4", features = ["derive"] }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
+pallas-addresses = "1.0.0-alpha.2"
+pallas-crypto = "1.0.0-alpha.2"
+pallas-primitives = "1.0.0-alpha.2"
 rand = "0.9"
 schemars = "0.8"
 serde = "1"

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -16,10 +16,10 @@ clap = { version = "4", features = ["derive"] }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"
-pallas-addresses = "1.0.0-alpha.0"
-pallas-crypto = "1.0.0-alpha.0"
-pallas-primitives = "1.0.0-alpha.0"
-pallas-wallet = "1.0.0-alpha.0"
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
+pallas-wallet = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
 rand = "0.9"
 schemars = "0.8"
 serde = "1"

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -16,9 +16,9 @@ clap = { version = "4", features = ["derive"] }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
 rand = "0.9"
 schemars = "0.8"
 serde = "1"

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -16,9 +16,9 @@ clap = { version = "4", features = ["derive"] }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
 rand = "0.9"
 schemars = "0.8"
 serde = "1"

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -16,9 +16,9 @@ clap = { version = "4", features = ["derive"] }
 firefly-server = { path = "../firefly-server" }
 hex = "0.4"
 minicbor = "0.26"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
 rand = "0.9"
 schemars = "0.8"
 serde = "1"

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardanosigner"
-version = "0.4.1"
+version = "0.4.2"
 description = "A service managing keys and signing for the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanosigner/src/keys.rs
+++ b/firefly-cardanosigner/src/keys.rs
@@ -8,10 +8,9 @@ use pallas_crypto::{
     key::ed25519::{SecretKey, SecretKeyExtended},
 };
 use pallas_primitives::conway::PlutusData::BoundedBytes;
-use pallas_wallet::PrivateKey;
 use serde::Deserialize;
 
-use crate::config::FileWalletConfig;
+use crate::{config::FileWalletConfig, private_key::PrivateKey};
 
 #[derive(Default)]
 pub struct KeyStore {

--- a/firefly-cardanosigner/src/main.rs
+++ b/firefly-cardanosigner/src/main.rs
@@ -15,6 +15,7 @@ use tracing::instrument;
 
 mod config;
 mod keys;
+mod private_key;
 mod routes;
 
 async fn health() -> impl IntoApiResponse {

--- a/firefly-cardanosigner/src/private_key.rs
+++ b/firefly-cardanosigner/src/private_key.rs
@@ -1,0 +1,26 @@
+use pallas_crypto::key::ed25519::{PublicKey, SecretKey, SecretKeyExtended, Signature};
+
+/// A standard or extended Ed25519 secret key
+pub enum PrivateKey {
+    Normal(SecretKey),
+    Extended(SecretKeyExtended),
+}
+
+impl PrivateKey {
+    pub fn public_key(&self) -> PublicKey {
+        match self {
+            Self::Normal(x) => x.public_key(),
+            Self::Extended(x) => x.public_key(),
+        }
+    }
+
+    pub fn sign<T>(&self, msg: T) -> Signature
+    where
+        T: AsRef<[u8]>,
+    {
+        match self {
+            Self::Normal(x) => x.sign(msg),
+            Self::Extended(x) => x.sign(msg),
+        }
+    }
+}

--- a/firefly-server/Cargo.toml
+++ b/firefly-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-server"
-version = "0.4.1"
+version = "0.4.2"
 description = "Internal library with shared code for services"
 license-file.workspace = true
 publish = false

--- a/scripts/demo/Cargo.toml
+++ b/scripts/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-demo"
-version = "0.4.1"
+version = "0.4.2"
 description = "A demo of the firefly-cardanoconnect API"
 license-file.workspace = true
 publish = false

--- a/scripts/deploy-contract/Cargo.toml
+++ b/scripts/deploy-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-deploy-contract"
-version = "0.4.1"
+version = "0.4.2"
 description = "A script to build and deploy a Balius smart contract to the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/scripts/deploy/Cargo.toml
+++ b/scripts/deploy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-deploy"
-version = "0.4.1"
+version = "0.4.2"
 description = "A script to build and deploy a Balius-backed API to FireFly"
 license-file.workspace = true
 publish = false

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -13,8 +13,8 @@ bech32 = "0.11"
 clap = { version = "4", features = ["derive"] }
 hex = "0.4"
 minicbor = "0.26"
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -13,8 +13,8 @@ bech32 = "0.11"
 clap = { version = "4", features = ["derive"] }
 hex = "0.4"
 minicbor = "0.26"
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -13,8 +13,8 @@ bech32 = "0.11"
 clap = { version = "4", features = ["derive"] }
 hex = "0.4"
 minicbor = "0.26"
-pallas-crypto = "1.0.0-alpha.0"
-pallas-primitives = "1.0.0-alpha.0"
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -13,8 +13,8 @@ bech32 = "0.11"
 clap = { version = "4", features = ["derive"] }
 hex = "0.4"
 minicbor = "0.26"
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -13,8 +13,8 @@ bech32 = "0.11"
 clap = { version = "4", features = ["derive"] }
 hex = "0.4"
 minicbor = "0.26"
-pallas-crypto = { git = "https://github.com/txpipe/pallas.git", rev = "2ddb5b066bbde9d2ed55014b286f47ad370b828e" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas.git", rev = "2ddb5b066bbde9d2ed55014b286f47ad370b828e" }
+pallas-crypto = "1.0.0-alpha.0"
+pallas-primitives = "1.0.0-alpha.0"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -13,8 +13,8 @@ bech32 = "0.11"
 clap = { version = "4", features = ["derive"] }
 hex = "0.4"
 minicbor = "0.26"
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
+pallas-crypto = "1.0.0-alpha.2"
+pallas-primitives = "1.0.0-alpha.2"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-generate-key"
-version = "0.4.1"
+version = "0.4.2"
 description = "A script to easily generate Cardano addresses"
 license-file.workspace = true
 publish = false

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -13,8 +13,8 @@ bech32 = "0.11"
 clap = { version = "4", features = ["derive"] }
 hex = "0.4"
 minicbor = "0.26"
-pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
+pallas-crypto = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
+pallas-primitives = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -886,7 +886,8 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8607c96619346ae83368f9b16e557293cc6de815ed273e934135622929400d01"
 dependencies = [
  "base58",
  "bech32",
@@ -913,7 +914,8 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995cde7561700117bac5fdc3b5b4593fe1217e9cbec366a71553afae82bccb0c"
 dependencies = [
  "hex",
  "minicbor 0.26.4",
@@ -939,7 +941,8 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c8592dbb853856ff75666fff21f49695ccab15b625b49bc875de328e631dc4"
 dependencies = [
  "cryptoxide",
  "hex",

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -886,7 +886,7 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
+source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
 dependencies = [
  "base58",
  "bech32",
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
+source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
 dependencies = [
  "hex",
  "minicbor 0.26.4",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
+source = "git+https://github.com/txpipe/pallas?rev=de9a0ea#de9a0eabbc87491440e43ef816101cd6a8086b7a"
 dependencies = [
  "cryptoxide",
  "hex",

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -885,16 +885,16 @@ dependencies = [
 
 [[package]]
 name = "pallas-addresses"
-version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
+version = "1.0.0-alpha.1"
+source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
 dependencies = [
  "base58",
  "bech32",
  "crc",
  "cryptoxide",
  "hex",
- "pallas-codec 1.0.0-alpha.0",
- "pallas-crypto 1.0.0-alpha.0",
+ "pallas-codec 1.0.0-alpha.1",
+ "pallas-crypto 1.0.0-alpha.1",
  "thiserror 1.0.69",
 ]
 
@@ -912,8 +912,8 @@ dependencies = [
 
 [[package]]
 name = "pallas-codec"
-version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
+version = "1.0.0-alpha.1"
+source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
 dependencies = [
  "hex",
  "minicbor 0.26.4",
@@ -938,12 +938,12 @@ dependencies = [
 
 [[package]]
 name = "pallas-crypto"
-version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
+version = "1.0.0-alpha.1"
+source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
 dependencies = [
  "cryptoxide",
  "hex",
- "pallas-codec 1.0.0-alpha.0",
+ "pallas-codec 1.0.0-alpha.1",
  "rand_core",
  "serde",
  "thiserror 1.0.69",
@@ -1311,7 +1311,7 @@ version = "0.1.0"
 dependencies = [
  "firefly-balius",
  "hex",
- "pallas-addresses 1.0.0-alpha.0",
+ "pallas-addresses 1.0.0-alpha.1",
  "serde",
 ]
 

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "258e9d00f2a7b551cf930812a865a0d3e1e87b508c96a121296c7d2774b0ba88"
 dependencies = [
  "balius-macros",
  "hex",
- "pallas-addresses",
- "pallas-codec",
- "pallas-crypto",
+ "pallas-addresses 0.32.0",
+ "pallas-codec 0.32.0",
+ "pallas-crypto 0.32.0",
  "pallas-primitives",
  "pallas-traverse",
  "prost",
@@ -787,7 +787,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0452a60c1863c1f50b5f77cd295e8d2786849f35883f0b9e18e7e6e1b5691b0"
 dependencies = [
  "half",
- "minicbor-derive",
+ "minicbor-derive 0.15.3",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb9d59e79ad66121ab441a0d1950890906a41e01ae14145ecf8401aa8894f50"
+dependencies = [
+ "half",
+ "minicbor-derive 0.16.2",
 ]
 
 [[package]]
@@ -795,6 +805,17 @@ name = "minicbor-derive"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9882ef5c56df184b8ffc107fc6c61e33ee3a654b021961d790a78571bb9d67a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -857,8 +878,24 @@ dependencies = [
  "crc",
  "cryptoxide",
  "hex",
- "pallas-codec",
- "pallas-crypto",
+ "pallas-codec 0.32.0",
+ "pallas-crypto 0.32.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pallas-addresses"
+version = "1.0.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f39c3f7a9a5f23e1dce67d8bf5d5f86320b470132304d7c63a5c380ebbe88daf"
+dependencies = [
+ "base58",
+ "bech32",
+ "crc",
+ "cryptoxide",
+ "hex",
+ "pallas-codec 1.0.0-alpha.0",
+ "pallas-crypto 1.0.0-alpha.0",
  "thiserror 1.0.69",
 ]
 
@@ -869,7 +906,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1584d615857c0a44058fb612e892e9e0cc47b56c3c82cdf7347b5c1d1193598c"
 dependencies = [
  "hex",
- "minicbor",
+ "minicbor 0.25.1",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pallas-codec"
+version = "1.0.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b0ecbf95c2dfdfec43e43f2b23f7742bf44a9088141bcc21b64322a6c9fb1a"
+dependencies = [
+ "hex",
+ "minicbor 0.26.4",
  "serde",
  "thiserror 1.0.69",
 ]
@@ -882,11 +931,25 @@ checksum = "37c1d642326ce402eb9191aeacc3dd0bf2b499848e97a56396c978a6eb9dd31a"
 dependencies = [
  "cryptoxide",
  "hex",
- "pallas-codec",
+ "pallas-codec 0.32.0",
  "rand_core",
  "serde",
  "thiserror 1.0.69",
  "zeroize",
+]
+
+[[package]]
+name = "pallas-crypto"
+version = "1.0.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ea22315c02348d6a96b56a7dbec5dde1e13e19e901e8de45fd41829e38ecae"
+dependencies = [
+ "cryptoxide",
+ "hex",
+ "pallas-codec 1.0.0-alpha.0",
+ "rand_core",
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -899,8 +962,8 @@ dependencies = [
  "bech32",
  "hex",
  "log",
- "pallas-codec",
- "pallas-crypto",
+ "pallas-codec 0.32.0",
+ "pallas-crypto 0.32.0",
  "serde",
  "serde_json",
 ]
@@ -913,9 +976,9 @@ checksum = "02d2572d316883fe866ae648bc3c5357e70cbbe8de5d78b1246f6109520fa52f"
 dependencies = [
  "hex",
  "itertools 0.13.0",
- "pallas-addresses",
- "pallas-codec",
- "pallas-crypto",
+ "pallas-addresses 0.32.0",
+ "pallas-codec 0.32.0",
+ "pallas-crypto 0.32.0",
  "pallas-primitives",
  "paste",
  "serde",
@@ -1251,7 +1314,7 @@ version = "0.1.0"
 dependencies = [
  "firefly-balius",
  "hex",
- "pallas-addresses",
+ "pallas-addresses 1.0.0-alpha.0",
  "serde",
 ]
 

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -300,7 +300,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "firefly-balius"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "balius-sdk",
  "hex",

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -885,17 +885,17 @@ dependencies = [
 
 [[package]]
 name = "pallas-addresses"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8607c96619346ae83368f9b16e557293cc6de815ed273e934135622929400d01"
+checksum = "f3f0bf697964d0562ee36727834f3fb698bdcf71dc2fef8c2f15e4e8920c6b55"
 dependencies = [
  "base58",
  "bech32",
  "crc",
  "cryptoxide",
  "hex",
- "pallas-codec 1.0.0-alpha.1",
- "pallas-crypto 1.0.0-alpha.1",
+ "pallas-codec 1.0.0-alpha.2",
+ "pallas-crypto 1.0.0-alpha.2",
  "thiserror 1.0.69",
 ]
 
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-codec"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995cde7561700117bac5fdc3b5b4593fe1217e9cbec366a71553afae82bccb0c"
+checksum = "51205265dc1f976a09e845abb4303e6704de54e377d3350ee30be70b26249f7f"
 dependencies = [
  "hex",
  "minicbor 0.26.4",
@@ -940,13 +940,13 @@ dependencies = [
 
 [[package]]
 name = "pallas-crypto"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c8592dbb853856ff75666fff21f49695ccab15b625b49bc875de328e631dc4"
+checksum = "4d62094c2f70164cd878b4f3ae2f81f79aca79d7b3a2a5db2fa15d09002d5f7d"
 dependencies = [
  "cryptoxide",
  "hex",
- "pallas-codec 1.0.0-alpha.1",
+ "pallas-codec 1.0.0-alpha.2",
  "rand_core",
  "serde",
  "thiserror 1.0.69",
@@ -1314,7 +1314,7 @@ version = "0.1.0"
 dependencies = [
  "firefly-balius",
  "hex",
- "pallas-addresses 1.0.0-alpha.1",
+ "pallas-addresses 1.0.0-alpha.2",
  "serde",
 ]
 

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -886,7 +886,7 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
+source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
 dependencies = [
  "base58",
  "bech32",
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
+source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
 dependencies = [
  "hex",
  "minicbor 0.26.4",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
+source = "git+https://github.com/txpipe/pallas?rev=54f300f#54f300fa1e32375a27d4a8e8989fd0e8449eaf83"
 dependencies = [
  "cryptoxide",
  "hex",

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -886,7 +886,7 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
+source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
 dependencies = [
  "base58",
  "bech32",
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
+source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
 dependencies = [
  "hex",
  "minicbor 0.26.4",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "1.0.0-alpha.1"
-source = "git+https://github.com/txpipe/pallas?rev=b720f78#b720f78713a4fc54fce3a633ff2e3767ddce2d2e"
+source = "git+https://github.com/txpipe/pallas?rev=8ae9cd0#8ae9cd0df065783c6d4f29a4f257bb9913509b67"
 dependencies = [
  "cryptoxide",
  "hex",

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -886,8 +886,7 @@ dependencies = [
 [[package]]
 name = "pallas-addresses"
 version = "1.0.0-alpha.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39c3f7a9a5f23e1dce67d8bf5d5f86320b470132304d7c63a5c380ebbe88daf"
+source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
 dependencies = [
  "base58",
  "bech32",
@@ -914,8 +913,7 @@ dependencies = [
 [[package]]
 name = "pallas-codec"
 version = "1.0.0-alpha.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b0ecbf95c2dfdfec43e43f2b23f7742bf44a9088141bcc21b64322a6c9fb1a"
+source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
 dependencies = [
  "hex",
  "minicbor 0.26.4",
@@ -941,8 +939,7 @@ dependencies = [
 [[package]]
 name = "pallas-crypto"
 version = "1.0.0-alpha.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10ea22315c02348d6a96b56a7dbec5dde1e13e19e901e8de45fd41829e38ecae"
+source = "git+https://github.com/txpipe/pallas?rev=a202cbb#a202cbb8f58bd5f516b171b14eec785d390bbbb8"
 dependencies = [
  "cryptoxide",
  "hex",

--- a/wasm/simple-tx/Cargo.toml
+++ b/wasm/simple-tx/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/hyperledger/firefly-cardano"
 [dependencies]
 firefly-balius = { path = "../../firefly-balius" }
 hex = "0.4"
-pallas-addresses = "1.0.0-alpha.0"
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
 serde = { version = "1", features = ["derive"] }
 
 [lib]

--- a/wasm/simple-tx/Cargo.toml
+++ b/wasm/simple-tx/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/hyperledger/firefly-cardano"
 [dependencies]
 firefly-balius = { path = "../../firefly-balius" }
 hex = "0.4"
-pallas-addresses = "1.0.0-alpha.1"
+pallas-addresses = "1.0.0-alpha.2"
 serde = { version = "1", features = ["derive"] }
 
 [lib]

--- a/wasm/simple-tx/Cargo.toml
+++ b/wasm/simple-tx/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/hyperledger/firefly-cardano"
 [dependencies]
 firefly-balius = { path = "../../firefly-balius" }
 hex = "0.4"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
 serde = { version = "1", features = ["derive"] }
 
 [lib]

--- a/wasm/simple-tx/Cargo.toml
+++ b/wasm/simple-tx/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/hyperledger/firefly-cardano"
 [dependencies]
 firefly-balius = { path = "../../firefly-balius" }
 hex = "0.4"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "b720f78" }
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
 serde = { version = "1", features = ["derive"] }
 
 [lib]

--- a/wasm/simple-tx/Cargo.toml
+++ b/wasm/simple-tx/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/hyperledger/firefly-cardano"
 [dependencies]
 firefly-balius = { path = "../../firefly-balius" }
 hex = "0.4"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "a202cbb" }
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "54f300f" }
 serde = { version = "1", features = ["derive"] }
 
 [lib]

--- a/wasm/simple-tx/Cargo.toml
+++ b/wasm/simple-tx/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/hyperledger/firefly-cardano"
 [dependencies]
 firefly-balius = { path = "../../firefly-balius" }
 hex = "0.4"
-pallas-addresses = "0.32"
+pallas-addresses = "1.0.0-alpha.0"
 serde = { version = "1", features = ["derive"] }
 
 [lib]

--- a/wasm/simple-tx/Cargo.toml
+++ b/wasm/simple-tx/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/hyperledger/firefly-cardano"
 [dependencies]
 firefly-balius = { path = "../../firefly-balius" }
 hex = "0.4"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "8ae9cd0" }
+pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
 serde = { version = "1", features = ["derive"] }
 
 [lib]

--- a/wasm/simple-tx/Cargo.toml
+++ b/wasm/simple-tx/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/hyperledger/firefly-cardano"
 [dependencies]
 firefly-balius = { path = "../../firefly-balius" }
 hex = "0.4"
-pallas-addresses = { git = "https://github.com/txpipe/pallas", rev = "de9a0ea" }
+pallas-addresses = "1.0.0-alpha.1"
 serde = { version = "1", features = ["derive"] }
 
 [lib]


### PR DESCRIPTION
# Context

Most Cardano Rust projects are built on top of the `pallas` collection of crates. Pallas is gearing up to release a v1 with a stable interface. We want to be sure that the new library works for the FireFly connector, and identify anything in Pallas that needs fixing pre-release.

# Important Changes Introduced

Upgrade all `pallas` crates to the latest version, currently based off of `1.0.0-alpha.2`.

The changes are mostly related to serialization of network structs. We've also made a copy of a small utility from `pallas-wallet`, as that module has been deleted.