### PR TITLE
chore: update images used in CI

### DIFF
--- a/infra/docker-compose.common.yaml
+++ b/infra/docker-compose.common.yaml
@@ -1,6 +1,6 @@
 services:
   firefly-core:
-    image: ghcr.io/gytis-ivaskevicius/firefly-core:latest
+    image: ghcr.io/hyperledger/firefly:v1.3.3-20250523-823
     volumes:
       - ./firefly-core.yaml:/etc/firefly/firefly.core.yml:ro
     ports:

--- a/infra/docker-compose.node.yaml
+++ b/infra/docker-compose.node.yaml
@@ -2,7 +2,7 @@ include:
   - docker-compose.common.yaml
 services:
   init-node:
-    image: ghcr.io/input-output-hk/mithril-client:2517.1-b1a2faa
+    image: ghcr.io/input-output-hk/mithril-client:2524.0-7bf7033
     entrypoint: /app/bin/entrypoint.sh
     user: "${UID}:${GID}"
     environment:
@@ -13,7 +13,7 @@ services:
     - node-db:/data
 
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:10.3.1
+    image: ghcr.io/intersectmbo/cardano-node:10.4.1
     user: "${UID}:${GID}"
     environment:
       NETWORK: preview


### PR DESCRIPTION
# Context

New versions of our deps are out. Let's use em!

# Important Changes Introduced

Upgrades cardano-node and mithril-client to their latest versions. Also updates the version of firefly-core we spin up, to a version from the main branch which knows about Cardano.

This fixes the build.