### PR TITLE
API versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-balius"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "balius-sdk",
  "hex",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-demo"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-deploy"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-deploy-contract"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-generate-key"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardanoconnect"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aide",
  "anyhow",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardanosigner"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aide",
  "anyhow",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-server"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aide",
  "anyhow",

--- a/firefly-balius/Cargo.toml
+++ b/firefly-balius/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-balius"
-version = "0.5.0"
+version = "0.6.0"
 description = "Helpers to write contracts for the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardanoconnect"
-version = "0.5.0"
+version = "0.6.0"
 description = "An implementation of the FireFly Connector API for Cardano"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanoconnect/src/main.rs
+++ b/firefly-cardanoconnect/src/main.rs
@@ -124,5 +124,5 @@ async fn main() -> Result<()> {
         .route("/ws", axum::routing::get(handle_socket_upgrade))
         .with_state(state);
 
-    firefly_server::server::serve(&config.api, router).await
+    firefly_server::server::serve(&config.api, [("v1", router)]).await
 }

--- a/firefly-cardanoconnect/src/signer.rs
+++ b/firefly-cardanoconnect/src/signer.rs
@@ -18,7 +18,7 @@ impl CardanoSigner {
     pub fn new(config: &CardanoConnectConfig) -> Result<Self> {
         let client = HttpClient::new(&config.http)?;
         let base_url = Url::parse(&config.connector.signer_url)?;
-        let sign_url = base_url.join("/sign")?;
+        let sign_url = base_url.join("/api/v1/sign")?;
         Ok(Self { client, sign_url })
     }
 

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardanosigner"
-version = "0.5.0"
+version = "0.6.0"
 description = "A service managing keys and signing for the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanosigner/src/main.rs
+++ b/firefly-cardanosigner/src/main.rs
@@ -61,5 +61,5 @@ async fn main() -> Result<()> {
         .api_route("/health", get(health))
         .api_route("/sign", post(sign_transaction))
         .with_state(state);
-    firefly_server::server::serve(&config.api, router).await
+    firefly_server::server::serve(&config.api, [("v1", router)]).await
 }

--- a/firefly-server/Cargo.toml
+++ b/firefly-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-server"
-version = "0.5.0"
+version = "0.6.0"
 description = "Internal library with shared code for services"
 license-file.workspace = true
 publish = false

--- a/firefly-server/src/server.rs
+++ b/firefly-server/src/server.rs
@@ -24,37 +24,46 @@ async fn serve_api(Extension(api): Extension<OpenApi>) -> impl IntoApiResponse {
     NoApi(Json(api))
 }
 
-pub async fn serve(config: &ApiConfig, router: ApiRouter) -> Result<()> {
-    // add common routes
-    let swagger_ui_router: Router = SwaggerUi::new("/api")
-        .config(Config::new(["/api/openapi.json"]))
-        .into();
-    let app = router
-        .route("/api/openapi.json", get(serve_api))
-        .merge(swagger_ui_router);
+pub async fn serve(
+    config: &ApiConfig,
+    versions: impl IntoIterator<Item = (&str, ApiRouter)>,
+) -> Result<()> {
+    let mut router = Router::<()>::new();
 
-    let mut api = OpenApi {
+    let base_api = OpenApi {
         info: config.info.clone(),
         ..OpenApi::default()
     };
-    if api.info.version.is_empty() {
-        api.info.version = env!("CARGO_PKG_VERSION").to_string();
+    let mut urls = vec![];
+    for (version, api_router) in versions {
+        let prefix = format!("/api/{version}");
+        let api_router = api_router.route("/openapi.json", get(serve_api));
+
+        urls.push(format!("{prefix}/openapi.json"));
+
+        let mut api = base_api.clone();
+        api.info.version = version.to_string();
+        let api_router = ApiRouter::new()
+            .nest(&prefix, api_router)
+            .finish_api(&mut api)
+            .layer(Extension(api));
+        router = router.merge(api_router);
     }
 
+    let swagger_ui_router: Router = SwaggerUi::new("/api").config(Config::new(urls)).into();
+    router = router.merge(swagger_ui_router);
+
     let listener = TcpListener::bind(format!("{}:{}", config.address, config.port)).await?;
-
-    info!("{} is now running on port {}", api.info.title, config.port);
-
+    info!(
+        "{} is now running on port {}",
+        config.info.title, config.port
+    );
     axum::serve(
         listener,
-        app.finish_api(&mut api)
-            .layer(Extension(api))
-            .layer(TraceLayer::new_for_http())
-            .into_make_service(),
+        router.layer(TraceLayer::new_for_http()).into_make_service(),
     )
     .with_graceful_shutdown(shutdown_signal())
     .await?;
-
     Ok(())
 }
 

--- a/scripts/demo/Cargo.toml
+++ b/scripts/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-demo"
-version = "0.5.0"
+version = "0.6.0"
 description = "A demo of the firefly-cardanoconnect API"
 license-file.workspace = true
 publish = false

--- a/scripts/demo/src/firefly.rs
+++ b/scripts/demo/src/firefly.rs
@@ -13,7 +13,7 @@ impl FireflyCardanoClient {
     pub fn new(base_url: &str) -> Self {
         Self {
             client: Client::new(),
-            v1_base_url: format!("${base_url}/api/v1"),
+            v1_base_url: format!("{base_url}/api/v1"),
         }
     }
 

--- a/scripts/demo/src/firefly.rs
+++ b/scripts/demo/src/firefly.rs
@@ -6,19 +6,19 @@ use serde_json::Value;
 
 pub struct FireflyCardanoClient {
     client: Client,
-    base_url: String,
+    v1_base_url: String,
 }
 
 impl FireflyCardanoClient {
     pub fn new(base_url: &str) -> Self {
         Self {
             client: Client::new(),
-            base_url: base_url.to_string(),
+            v1_base_url: format!("${base_url}/api/v1"),
         }
     }
 
     pub async fn get_chain_tip(&self) -> Result<Tip> {
-        let url = format!("{}/chain/tip", self.base_url);
+        let url = format!("{}/chain/tip", self.v1_base_url);
         let res = self.client.get(url).send().await?;
         let res = Self::extract_error(res).await?;
         let body: Tip = res.json().await?;
@@ -32,7 +32,7 @@ impl FireflyCardanoClient {
         method: &str,
         params: impl IntoIterator<Item = (&str, Value)>,
     ) -> Result<Option<String>> {
-        let url = format!("{}/contracts/invoke", self.base_url);
+        let url = format!("{}/contracts/invoke", self.v1_base_url);
         let op_id = uuid::Uuid::new_v4().to_string();
         let mut req = InvokeContractRequest {
             address: address.to_string(),
@@ -52,7 +52,7 @@ impl FireflyCardanoClient {
         Self::extract_error(res).await?;
 
         // contracts are synchronous, so the result is already available
-        let url = format!("{}/transactions/{op_id}", self.base_url);
+        let url = format!("{}/transactions/{op_id}", self.v1_base_url);
         let res = self.client.get(url).send().await?;
         let res = Self::extract_error(res).await?;
         let body: OperationStatus = res.json().await?;
@@ -66,7 +66,7 @@ impl FireflyCardanoClient {
     }
 
     pub async fn create_stream(&self, settings: &StreamSettings) -> Result<String> {
-        let url = format!("{}/eventstreams", self.base_url);
+        let url = format!("{}/eventstreams", self.v1_base_url);
         let res = self.client.post(url).json(settings).send().await?;
         let res = Self::extract_error(res).await?;
         let body: EventStream = res.json().await?;
@@ -74,7 +74,7 @@ impl FireflyCardanoClient {
     }
 
     pub async fn list_streams(&self) -> Result<Vec<EventStream>> {
-        let url = format!("{}/eventstreams", self.base_url);
+        let url = format!("{}/eventstreams", self.v1_base_url);
         let res = self.client.get(url).send().await?;
         let res = Self::extract_error(res).await?;
         let body: Vec<EventStream> = res.json().await?;
@@ -86,7 +86,7 @@ impl FireflyCardanoClient {
         stream_id: &str,
         settings: &ListenerSettings,
     ) -> Result<String> {
-        let url = format!("{}/eventstreams/{}/listeners", self.base_url, stream_id);
+        let url = format!("{}/eventstreams/{}/listeners", self.v1_base_url, stream_id);
         let res = self.client.post(url).json(settings).send().await?;
         let res = Self::extract_error(res).await?;
         let body: Listener = res.json().await?;
@@ -94,7 +94,7 @@ impl FireflyCardanoClient {
     }
 
     pub async fn list_listeners(&self, stream_id: &str) -> Result<Vec<Listener>> {
-        let url = format!("{}/eventstreams/{}/listeners", self.base_url, stream_id);
+        let url = format!("{}/eventstreams/{}/listeners", self.v1_base_url, stream_id);
         let res = self.client.get(url).send().await?;
         let res = Self::extract_error(res).await?;
         let body: Vec<Listener> = res.json().await?;
@@ -104,7 +104,7 @@ impl FireflyCardanoClient {
     pub async fn delete_listener(&self, stream_id: &str, listener_id: &str) -> Result<()> {
         let url = format!(
             "{}/eventstreams/{}/listeners/{}",
-            self.base_url, stream_id, listener_id
+            self.v1_base_url, stream_id, listener_id
         );
         let res = self.client.delete(url).send().await?;
         Self::extract_error(res).await?;
@@ -112,7 +112,7 @@ impl FireflyCardanoClient {
     }
 
     pub async fn connect_ws(&self) -> Result<WebSocket> {
-        let url = format!("{}/ws", self.base_url);
+        let url = format!("{}/ws", self.v1_base_url);
         let res = self.client.get(url).upgrade().send().await?;
         Ok(res.into_websocket().await?)
     }

--- a/scripts/deploy-contract/Cargo.toml
+++ b/scripts/deploy-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-deploy-contract"
-version = "0.5.0"
+version = "0.6.0"
 description = "A script to build and deploy a Balius smart contract to the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/scripts/deploy-contract/src/firefly.rs
+++ b/scripts/deploy-contract/src/firefly.rs
@@ -12,7 +12,7 @@ impl FireflyCardanoClient {
     pub fn new(base_url: &str) -> Self {
         Self {
             client: Client::new(),
-            v1_base_url: format!("${base_url}/api/v1"),
+            v1_base_url: format!("{base_url}/api/v1"),
         }
     }
 

--- a/scripts/deploy-contract/src/firefly.rs
+++ b/scripts/deploy-contract/src/firefly.rs
@@ -5,19 +5,19 @@ use uuid::Uuid;
 
 pub struct FireflyCardanoClient {
     client: Client,
-    base_url: String,
+    v1_base_url: String,
 }
 
 impl FireflyCardanoClient {
     pub fn new(base_url: &str) -> Self {
         Self {
             client: Client::new(),
-            base_url: base_url.to_string(),
+            v1_base_url: format!("${base_url}/api/v1"),
         }
     }
 
     pub async fn deploy_contract(&self, name: &str, version: &str, contract: &str) -> Result<()> {
-        let url = format!("{}/contracts/deploy", self.base_url);
+        let url = format!("{}/contracts/deploy", self.v1_base_url);
         let req = DeployContractRequest {
             id: Uuid::new_v4().to_string(),
             contract: contract.to_string(),

--- a/scripts/deploy-contract/src/main.rs
+++ b/scripts/deploy-contract/src/main.rs
@@ -66,10 +66,7 @@ async fn main() -> Result<()> {
     let contract = hex::encode(&component);
 
     println!("Deploying {address} to FireFly...");
-    let base_url = args
-        .firefly_url
-        .map(|u| format!("{u}/api/v1"))
-        .unwrap_or(args.firefly_cardano_url);
+    let base_url = args.firefly_url.unwrap_or(args.firefly_cardano_url);
     let firefly = FireflyCardanoClient::new(&base_url);
     firefly.deploy_contract(&name, &version, &contract).await?;
 

--- a/scripts/deploy/Cargo.toml
+++ b/scripts/deploy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-deploy"
-version = "0.5.0"
+version = "0.6.0"
 description = "A script to build and deploy a Balius-backed API to FireFly"
 license-file.workspace = true
 publish = false

--- a/scripts/deploy/src/clients/firefly.rs
+++ b/scripts/deploy/src/clients/firefly.rs
@@ -6,19 +6,19 @@ use serde::{Deserialize, Serialize};
 
 pub struct FireflyClient {
     client: Client,
-    base_url: String,
+    v1_base_url: String,
 }
 
 impl FireflyClient {
     pub fn new(base_url: &str) -> Self {
         Self {
             client: Client::new(),
-            base_url: format!("{base_url}/api/v1"),
+            v1_base_url: format!("{base_url}/api/v1"),
         }
     }
 
     pub async fn deploy_contract(&self, req: &DeployContractRequest) -> Result<ContractLocation> {
-        let url = format!("{}/contracts/deploy", self.base_url);
+        let url = format!("{}/contracts/deploy", self.v1_base_url);
         let res = self.client.post(url).json(req).send().await?;
         let res = Self::extract_error(res).await?;
         let body: DeployContractResponse = res.json().await?;
@@ -33,7 +33,7 @@ impl FireflyClient {
     }
 
     async fn try_get_interface(&self, name: &str, version: &str) -> Result<Option<Interface>> {
-        let url = format!("{}/contracts/interfaces/{name}/{version}", self.base_url);
+        let url = format!("{}/contracts/interfaces/{name}/{version}", self.v1_base_url);
         let res = self.client.get(url).send().await?;
         if res.status().as_u16() == 404 {
             return Ok(None);
@@ -44,7 +44,7 @@ impl FireflyClient {
     }
 
     async fn create_interface(&self, req: &ContractDefinition) -> Result<Interface> {
-        let url = format!("{}/contracts/interfaces", self.base_url);
+        let url = format!("{}/contracts/interfaces", self.v1_base_url);
         let res = self.client.post(url).json(req).send().await?;
         let res = Self::extract_error(res).await?;
         let body: Interface = res.json().await?;
@@ -52,7 +52,7 @@ impl FireflyClient {
     }
 
     async fn delete_interface(&self, id: &str) -> Result<()> {
-        let url = format!("{}/contracts/interfaces/{id}", self.base_url);
+        let url = format!("{}/contracts/interfaces/{id}", self.v1_base_url);
         let res = self.client.delete(url).send().await?;
         Self::extract_error(res).await?;
         Ok(())
@@ -67,7 +67,7 @@ impl FireflyClient {
     }
 
     async fn try_get_api(&self, name: &str) -> Result<Option<ApiResponse>> {
-        let url = format!("{}/apis/{name}", self.base_url);
+        let url = format!("{}/apis/{name}", self.v1_base_url);
         let res = self.client.get(url).send().await?;
         if res.status().as_u16() == 404 {
             return Ok(None);
@@ -78,7 +78,7 @@ impl FireflyClient {
     }
 
     async fn create_api(&self, req: &CreateApiRequest) -> Result<ApiResponse> {
-        let url = format!("{}/apis", self.base_url);
+        let url = format!("{}/apis", self.v1_base_url);
         let res = self.client.post(url).json(req).send().await?;
         let res = Self::extract_error(res).await?;
         let body: ApiResponse = res.json().await?;
@@ -86,7 +86,7 @@ impl FireflyClient {
     }
 
     async fn update_api(&self, req: &CreateApiRequest, id: &str) -> Result<ApiResponse> {
-        let url = format!("{}/apis/{id}", self.base_url);
+        let url = format!("{}/apis/{id}", self.v1_base_url);
         let res = self.client.put(url).json(req).send().await?;
         let res = Self::extract_error(res).await?;
         let body: ApiResponse = res.json().await?;
@@ -94,7 +94,7 @@ impl FireflyClient {
     }
 
     async fn poll_deploy_contract_location(&self, operation: &str) -> Result<ContractLocation> {
-        let url = format!("{}/operations/{operation}", self.base_url);
+        let url = format!("{}/operations/{operation}", self.v1_base_url);
         loop {
             let res = self.client.get(&url).send().await?;
             let res = Self::extract_error(res).await?;

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-generate-key"
-version = "0.5.0"
+version = "0.6.0"
 description = "A script to easily generate Cardano addresses"
 license-file.workspace = true
 publish = false

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -307,7 +307,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "firefly-balius"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "balius-sdk",
  "hex",


### PR DESCRIPTION
# Context

Enrique wants this to be the first connector to version its API.

# Important Changes Introduced

Both services now serve all API endpoints under the prefix /api/v1. We have infrastructure in place to add other API versions later. There's a single openapi URL which shows the API for all versions, at the same URL it was always in.