### PR TITLE
Multiplex operation updates fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-balius"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "balius-sdk",
  "hex",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-demo"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-deploy"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-deploy-contract"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-generate-key"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bech32 0.11.0",
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardanoconnect"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aide",
  "anyhow",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardanosigner"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aide",
  "anyhow",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aide",
  "anyhow",

--- a/firefly-balius/Cargo.toml
+++ b/firefly-balius/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-balius"
-version = "0.6.0"
+version = "0.6.1"
 description = "Helpers to write contracts for the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardanoconnect"
-version = "0.6.0"
+version = "0.6.1"
 description = "An implementation of the FireFly Connector API for Cardano"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanoconnect/src/routes/ws.rs
+++ b/firefly-cardanoconnect/src/routes/ws.rs
@@ -10,7 +10,7 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use tracing::{Level, error, instrument, warn};
+use tracing::{Level, error, info, instrument, warn};
 
 use crate::{
     AppState,
@@ -30,6 +30,7 @@ async fn handle_socket(
         IncomingMessage::Listen(ListenMessage { topic }) => topic,
         other => bail!("unexpected first message: {:?}", other),
     };
+    info!("caller listening on topic {topic}");
     let mut subscription = stream_manager.subscribe(&topic).await?;
 
     while let Some(batch) = subscription.recv().await {
@@ -238,7 +239,9 @@ pub async fn handle_socket_upgrade(
     State(app_state): State<AppState>,
     ws: WebSocketUpgrade,
 ) -> Response {
+    info!("Incoming websocket connection");
     ws.on_upgrade(|socket| async move {
+        info!("Websocket connection succeeded");
         if let Err(error) = handle_socket(app_state, socket).await {
             warn!("socket error: {:?}", error);
         }

--- a/firefly-cardanoconnect/src/streams/mux.rs
+++ b/firefly-cardanoconnect/src/streams/mux.rs
@@ -694,7 +694,11 @@ mod tests {
         batch.ack();
 
         // We don't receive any additional batches
-        assert!(timeout(Duration::from_millis(500), subscription.recv()).await.is_err());
+        assert!(
+            timeout(Duration::from_millis(500), subscription.recv())
+                .await
+                .is_err()
+        );
 
         // The checkpoint is updated
         let checkpoint = persistence.read_checkpoint(&stream.id).await?.unwrap();

--- a/firefly-cardanoconnect/src/streams/mux.rs
+++ b/firefly-cardanoconnect/src/streams/mux.rs
@@ -283,7 +283,7 @@ impl StreamDispatcherWorker {
         let mut batch_sink = None;
         loop {
             let (batch, ack_rx, last_op_id, hwms) = select! {
-                batch = self.build_batch(&mut operation_update_source), if batch_sink.is_some() && !self.listeners.is_empty() => batch,
+                batch = self.build_batch(&mut operation_update_source), if batch_sink.is_some() => batch,
                 Some(change) = state_change_source.recv() => {
                     match change {
                         StreamDispatcherStateChange::NewSettings(settings) => {
@@ -386,7 +386,7 @@ impl StreamDispatcherWorker {
         }
         while events.len() < self.batch_size {
             select! {
-                _ = self.collect_contract_events(hwms, events) => {}
+                _ = self.collect_contract_events(hwms, events), if !self.listeners.is_empty() => {}
                 Ok(()) = operation_update_source.changed() => {
                     self.collect_operation_events(last_op, events).await;
                 }
@@ -542,9 +542,11 @@ mod tests {
     use crate::{
         blockchain::BlockchainClient,
         contracts::ContractManager,
+        operations::{Operation, OperationId, OperationStatus},
         persistence,
         streams::{
-            BlockReference, Listener, ListenerFilter, ListenerType, Stream, mux::Multiplexer,
+            BatchEvent, BlockReference, Listener, ListenerFilter, ListenerType, Stream,
+            mux::Multiplexer,
         },
     };
     use firefly_server::apitypes::ApiError;
@@ -646,6 +648,48 @@ mod tests {
         assert_eq!(batch.batch_number, 1);
         assert_eq!(batch.events.len(), 5);
         assert_eq!(batch.events, old_events);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_surface_operation_updates_without_listeners() -> Result<(), ApiError> {
+        let blockchain = Arc::new(BlockchainClient::mock().await);
+        let contracts = Arc::new(ContractManager::none());
+        let persistence = persistence::init(&persistence::PersistenceConfig::Mock).await?;
+        let operation_update_sink = watch::Sender::new(None);
+        let mux = Multiplexer::new(
+            blockchain.clone(),
+            contracts,
+            persistence.clone(),
+            operation_update_sink.clone(),
+        )
+        .await?;
+
+        let stream = Stream {
+            id: "stream_id".to_string().into(),
+            name: "Some Stream".into(),
+            batch_size: 5,
+            batch_timeout: Duration::from_millis(100),
+        };
+        persistence.write_stream(&stream).await?;
+        mux.handle_stream_write(&stream).await?;
+
+        let mut subscription = mux.subscribe("Some Stream").await?;
+
+        let operation = Operation {
+            id: OperationId::from("op".to_string()),
+            status: OperationStatus::Pending,
+            tx_id: None,
+            contract_address: None,
+        };
+
+        let update_id = persistence.write_operation(&operation).await?;
+        operation_update_sink.send_replace(Some(update_id));
+
+        let batch = subscription.recv().await.unwrap();
+        assert_eq!(batch.batch_number, 1);
+        assert_eq!(batch.events, vec![BatchEvent::Receipt(operation)]);
 
         Ok(())
     }

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardanosigner"
-version = "0.6.0"
+version = "0.6.1"
 description = "A service managing keys and signing for the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/firefly-server/Cargo.toml
+++ b/firefly-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-server"
-version = "0.6.0"
+version = "0.6.1"
 description = "Internal library with shared code for services"
 license-file.workspace = true
 publish = false

--- a/scripts/demo/Cargo.toml
+++ b/scripts/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-demo"
-version = "0.6.0"
+version = "0.6.1"
 description = "A demo of the firefly-cardanoconnect API"
 license-file.workspace = true
 publish = false

--- a/scripts/deploy-contract/Cargo.toml
+++ b/scripts/deploy-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-deploy-contract"
-version = "0.6.0"
+version = "0.6.1"
 description = "A script to build and deploy a Balius smart contract to the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/scripts/deploy/Cargo.toml
+++ b/scripts/deploy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-deploy"
-version = "0.6.0"
+version = "0.6.1"
 description = "A script to build and deploy a Balius-backed API to FireFly"
 license-file.workspace = true
 publish = false

--- a/scripts/deploy/src/main.rs
+++ b/scripts/deploy/src/main.rs
@@ -31,6 +31,7 @@ async fn main() -> Result<()> {
         definition: serde_json::from_str(&definition_str)?,
     };
 
+    println!("Deploying contract to {}", args.firefly_url);
     let location = client.deploy_contract(&request).await?;
     println!("location: {}", serde_json::to_string(&location)?);
     let interface = client.deploy_interface(&request.definition).await?;

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-generate-key"
-version = "0.6.0"
+version = "0.6.1"
 description = "A script to easily generate Cardano addresses"
 license-file.workspace = true
 publish = false

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -307,7 +307,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "firefly-balius"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "balius-sdk",
  "hex",


### PR DESCRIPTION
# Context

The Cardano connector has complex "multiplexer" code, which collects internal events into "batches" of persistent messages which are routed to websocket-powered streams. The contents of a stream are determined by a set of client-controlled "listeners".

This connector reports some events (such as contract deployments) as "operation updates". These used to be ephemeral and provided with best-effort availability, the way they are in other connectors. We were asked to make this the first connector which provides "operation updates" persistent and include them in the same batches as other messages. When we did, I forgot to account for streams without any listeners .

# Important Changes Introduced

Make the cardano connector surface operation updates to all streams, even if those streams have no listeners. Also, add more logging.