### PR TITLE
chore: add dependabot config to group version and security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+updates:
+  # Rust / Cargo workspace (single Cargo.lock at repo root)
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      cargo:
+        # Group all non-security version updates into one PR
+        applies-to: version-updates
+        patterns:
+          - "*"
+      cargo-security:
+        # Group all security updates into one PR
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # GitHub Actions used by workflows in .github/workflows
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # Container base images (Dockerfile at repo root)
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      docker:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      docker-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
# Context

This will group dependabot changes by ecosystem as well as type

# Important Changes Introduced
