### PR TITLE
ci: tell dependabot more about rust dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,9 @@ version: 2
 updates:
   # Rust / Cargo workspace (single Cargo.lock at repo root)
   - package-ecosystem: cargo
-    directory: "/"
+    directories:
+      - "/"
+      - "/wasm/simple-tx/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
@@ -10,6 +12,11 @@ updates:
       cargo:
         # Group all non-security version updates into one PR
         applies-to: version-updates
+        exclude-patterns:
+          - "minicbor"      # stuck on an older version for compatibility with pallas
+          - "rusqlite"      # stuck on an older version for compatibility with refinery
+          - "schemars"      # stuck on an older version for compatibility with aide
+          - "utxorpc-spec"  # stuck on an older version for compatibility with balius
         patterns:
           - "*"
       cargo-security:


### PR DESCRIPTION
# Context

Dependabot is opening rust update PRs which break the build. It shouldn't.

# Important Changes Introduced

Exclude specific dependencies from the list to automatically update. These are dependencies which we can't upgrade to newer versions, because the newer version of a different library is not compatible with those. With this change, dependabot should only open PRs to update dependencies which _can_ be updated.

Also, tells dependabot about a nested Cargo.toml that's not part of the workspace. It had to be separate because of wasm antics.