### PR TITLE
chore: Release v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,7 +1171,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firefly-balius"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "balius-sdk",
  "hex",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-demo"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-deploy"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-deploy-contract"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardano-generate-key"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bech32 0.12.0",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardanoconnect"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "aide",
  "anyhow",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-cardanosigner"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "aide",
  "anyhow",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "firefly-server"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "aide",
  "anyhow",

--- a/firefly-balius/Cargo.toml
+++ b/firefly-balius/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-balius"
-version = "0.6.1"
+version = "0.7.0"
 description = "Helpers to write contracts for the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanoconnect/Cargo.toml
+++ b/firefly-cardanoconnect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardanoconnect"
-version = "0.6.1"
+version = "0.7.0"
 description = "An implementation of the FireFly Connector API for Cardano"
 license-file.workspace = true
 publish = false

--- a/firefly-cardanosigner/Cargo.toml
+++ b/firefly-cardanosigner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardanosigner"
-version = "0.6.1"
+version = "0.7.0"
 description = "A service managing keys and signing for the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/firefly-server/Cargo.toml
+++ b/firefly-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-server"
-version = "0.6.1"
+version = "0.7.0"
 description = "Internal library with shared code for services"
 license-file.workspace = true
 publish = false

--- a/scripts/demo/Cargo.toml
+++ b/scripts/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-demo"
-version = "0.6.1"
+version = "0.7.0"
 description = "A demo of the firefly-cardanoconnect API"
 license-file.workspace = true
 publish = false

--- a/scripts/deploy-contract/Cargo.toml
+++ b/scripts/deploy-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-deploy-contract"
-version = "0.6.1"
+version = "0.7.0"
 description = "A script to build and deploy a Balius smart contract to the FireFly Cardano connector"
 license-file.workspace = true
 publish = false

--- a/scripts/deploy/Cargo.toml
+++ b/scripts/deploy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-deploy"
-version = "0.6.1"
+version = "0.7.0"
 description = "A script to build and deploy a Balius-backed API to FireFly"
 license-file.workspace = true
 publish = false

--- a/scripts/generate-key/Cargo.toml
+++ b/scripts/generate-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firefly-cardano-generate-key"
-version = "0.6.1"
+version = "0.7.0"
 description = "A script to easily generate Cardano addresses"
 license-file.workspace = true
 publish = false

--- a/wasm/simple-tx/Cargo.lock
+++ b/wasm/simple-tx/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firefly-balius"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "balius-sdk",
  "hex",


### PR DESCRIPTION
# Context

Bump package versions to prepare for a new release.
Note that this won't _cut_  the release, we do that manually through the github UI. This just keeps package versions in sync everywhere.

# Important Changes Introduced

Bump everything to version 0.7.0