### PR TITLE
Improve docker build performance

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -18,8 +18,38 @@ jobs:
         with:
           toolchain: stable
           target: wasm32-unknown-unknown
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Docker login
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build cardanoconnect image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./
+          file: ./Dockerfile
+          load: true
+          platforms: linux/amd64
+          provenance: false
+          target: firefly-cardanoconnect
+          tags: ghcr.io/hyperledger-firefly/cardanoconnect:main
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+      - name: Build cardanosigner image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./
+          file: ./Dockerfile
+          load: true
+          platforms: linux/amd64
+          provenance: false
+          target: firefly-cardanosigner
+          tags: ghcr.io/hyperledger-firefly/cardanosigner:main
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
       - name: Start docker-compose
-        run: docker compose -f ./infra/docker-compose.node.yaml -p preview up  -d --build
+        run: docker compose -f ./infra/docker-compose.node.yaml -p preview up -d
       - name: Logs
         if: always()
         run: |

--- a/.github/workflows/docker-main.yml
+++ b/.github/workflows/docker-main.yml
@@ -9,7 +9,15 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run unit tests
+        run: cargo test --verbose
+
   docker:
+    needs: test
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,7 +8,15 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run unit tests
+        run: cargo test --verbose
+
   docker:
+    needs: test
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,6 @@ COPY firefly-server /app/firefly-server
 COPY Cargo.toml Cargo.lock /app/
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    cargo test
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     cargo build --release
 
 # Define separate targets for each service


### PR DESCRIPTION
# Context

Builds of this repo are slow. Some of that is the (currently) unavoidable full restoration of a preview Cardano node onto a fresh instance, but some is just wasted time in a Rust build. Optimize that build.

# Important Changes Introduced
 - Don't run `npm run test` when building the dockerfile (this avoids building the entire repo from scratch a second time, in debug mode)
 - Use caches inside of demo, so that rerunning it isn't as expensive